### PR TITLE
Persist trade requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SUPABASE_URL="https://your-project-ref.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-publishable-or-anon-key"
+SUPABASE_SERVICE_ROLE_KEY="your-server-only-service-role-key"
+AUTH_SECRET="your-auth-secret"
+AUTH_BASE_URL="http://localhost:3000"

--- a/app/api/requests/route.ts
+++ b/app/api/requests/route.ts
@@ -1,28 +1,82 @@
 import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+type RequestRow = {
+  request_id: string;
+  product_id: string;
+  buyer_id: string;
+  quantity: number;
+  note: string | null;
+  status: string;
+  created_at: string;
+};
+
+function toRequest(row: RequestRow) {
+  return {
+    id: row.request_id,
+    itemId: row.product_id,
+    buyerId: row.buyer_id,
+    quantity: row.quantity,
+    note: row.note ?? "",
+    status: row.status,
+    createdAt: row.created_at,
+  };
+}
 
 export async function POST(request: Request) {
-  const body = await request.json();
-  const itemId = String(body.itemId ?? "").trim();
-  const quantity = Number(body.quantity);
-  const note = String(body.note ?? "").trim();
+  try {
+    const session = await auth();
 
-  if (!itemId || !Number.isFinite(quantity) || quantity < 1) {
-    return NextResponse.json(
-      { message: "Item id and quantity are required." },
-      { status: 400 }
-    );
-  }
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to send a request." },
+        { status: 401 }
+      );
+    }
 
-  return NextResponse.json(
-    {
-      ok: true,
-      request: {
-        itemId,
+    const body = await request.json();
+    const itemId = String(body.itemId ?? "").trim();
+    const quantity = Number(body.quantity);
+    const note = String(body.note ?? "").trim();
+
+    if (!itemId || !Number.isInteger(quantity) || quantity < 1) {
+      return NextResponse.json(
+        { message: "Item id and quantity are required." },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("trade_requests")
+      .insert({
+        product_id: itemId,
+        buyer_id: session.user.id,
         quantity,
-        note,
+        note: note || null,
         status: "sent",
+      })
+      .select(
+        "request_id, product_id, buyer_id, quantity, note, status, created_at"
+      )
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        request: toRequest(data),
       },
-    },
-    { status: 201 }
-  );
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to send request.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
 }

--- a/supabase/mvp-schema.sql
+++ b/supabase/mvp-schema.sql
@@ -1,0 +1,26 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.trade_requests (
+  request_id uuid primary key default gen_random_uuid(),
+  product_id text not null,
+  buyer_id uuid not null references auth.users(id) on delete cascade,
+  quantity integer not null check (quantity > 0),
+  note text,
+  status text not null default 'sent' check (status in ('sent', 'accepted', 'declined', 'cancelled')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.trade_requests enable row level security;
+
+create policy "Buyers can create trade requests"
+  on public.trade_requests
+  for insert
+  to authenticated
+  with check (buyer_id = auth.uid());
+
+create policy "Buyers can read their trade requests"
+  on public.trade_requests
+  for select
+  to authenticated
+  using (buyer_id = auth.uid());

--- a/utils/supabase/admin.ts
+++ b/utils/supabase/admin.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Supabase admin credentials are not configured.");
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Require an authenticated NextAuth session before sending a trade request.
- Persist buyer requests into a new `trade_requests` Supabase table instead of returning a mock success payload.
- Add a server-only Supabase admin client for backend writes and document the required `SUPABASE_SERVICE_ROLE_KEY` in `.env.example`.
- Add `supabase/mvp-schema.sql` with the MVP request table and buyer-focused RLS policies.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- Local production smoke test on `http://localhost:3100/api/requests`: anonymous request returns `401`.

## Notes
- Apply `supabase/mvp-schema.sql` in the Supabase SQL editor.
- Add `SUPABASE_SERVICE_ROLE_KEY` to local `.env.local` and Vercel environment variables before validating authenticated request creation against the hosted database.