### PR TITLE
Track product seller ownership

### DIFF
--- a/app/api/products/[id]/route.ts
+++ b/app/api/products/[id]/route.ts
@@ -8,6 +8,8 @@ type ProductRow = {
   price: number;
   category: string | null;
   image_url: string | null;
+  seller_id: string | null;
+  status: string | null;
 };
 
 function toProduct(row: ProductRow) {
@@ -17,6 +19,8 @@ function toProduct(row: ProductRow) {
     price: row.price,
     category: row.category,
     imageUrl: row.image_url,
+    sellerId: row.seller_id,
+    status: row.status ?? "available",
   };
 }
 
@@ -30,7 +34,7 @@ export async function GET(
 
     const { data, error } = await supabase
       .from("products")
-      .select("product_id, name, price, category, image_url")
+      .select("product_id, name, price, category, image_url, seller_id, status")
       .eq("product_id", id)
       .single();
 

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { auth } from "@/auth";
+import { createAdminClient } from "@/utils/supabase/admin";
 import { createClient } from "@/utils/supabase/server";
 import { filterDemoProducts } from "@/app/lib/demoProducts";
 
@@ -9,6 +10,8 @@ type ProductRow = {
   price: number;
   category: string | null;
   image_url: string | null;
+  seller_id: string | null;
+  status: string | null;
 };
 
 function toProduct(row: ProductRow) {
@@ -18,6 +21,8 @@ function toProduct(row: ProductRow) {
     price: row.price,
     category: row.category,
     imageUrl: row.image_url,
+    sellerId: row.seller_id,
+    status: row.status ?? "available",
   };
 }
 
@@ -37,7 +42,7 @@ export async function GET(request: NextRequest) {
 
     let query = supabase
       .from("products")
-      .select("product_id, name, price, category, image_url", {
+      .select("product_id, name, price, category, image_url, seller_id, status", {
         count: "exact",
       });
 
@@ -96,14 +101,14 @@ export async function POST(request: NextRequest) {
   try {
     const session = await auth();
 
-    if (!session?.user) {
+    if (!session?.user?.id) {
       return NextResponse.json(
         { message: "You must be logged in to list an item." },
         { status: 401 }
       );
     }
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const body = await request.json();
     const name = String(body.name ?? "").trim();
     const category = String(body.category ?? "").trim();
@@ -124,8 +129,10 @@ export async function POST(request: NextRequest) {
         price,
         category: category || "general",
         image_url: imageUrl || null,
+        seller_id: session.user.id,
+        status: "available",
       })
-      .select("product_id, name, price, category, image_url")
+      .select("product_id, name, price, category, image_url, seller_id, status")
       .single();
 
     if (error) {

--- a/app/lib/products.tsx
+++ b/app/lib/products.tsx
@@ -4,6 +4,8 @@ export type Product = {
   price: number;
   category?: string | null;
   imageUrl?: string | null;
+  sellerId?: string | null;
+  status?: string | null;
 };
 
 export type ProductListResponse = {

--- a/supabase/mvp-schema.sql
+++ b/supabase/mvp-schema.sql
@@ -1,5 +1,35 @@
 create extension if not exists pgcrypto;
 
+alter table public.products
+  add column if not exists seller_id uuid references auth.users(id) on delete set null,
+  add column if not exists status text not null default 'available' check (status in ('available', 'pending', 'sold', 'removed')),
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.products enable row level security;
+
+drop policy if exists "Anyone can read available products" on public.products;
+create policy "Anyone can read available products"
+  on public.products
+  for select
+  to anon, authenticated
+  using (status = 'available');
+
+drop policy if exists "Sellers can create their products" on public.products;
+create policy "Sellers can create their products"
+  on public.products
+  for insert
+  to authenticated
+  with check (seller_id = auth.uid());
+
+drop policy if exists "Sellers can update their products" on public.products;
+create policy "Sellers can update their products"
+  on public.products
+  for update
+  to authenticated
+  using (seller_id = auth.uid())
+  with check (seller_id = auth.uid());
+
 create table if not exists public.trade_requests (
   request_id uuid primary key default gen_random_uuid(),
   product_id text not null,


### PR DESCRIPTION
## Summary
- Store the authenticated seller id when a user lists a product.
- Return `sellerId` and `status` in product list/detail API responses.
- Extend the MVP Supabase schema with `products.seller_id`, product status, and basic product ownership RLS policies.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- Local production smoke test on `http://localhost:3100/api/products`: anonymous product creation returns `401`.

## Notes
- Apply the updated `supabase/mvp-schema.sql` in the Supabase SQL editor.
- Product creation now uses the server-only Supabase admin client, so `SUPABASE_SERVICE_ROLE_KEY` must exist in local and Vercel env vars.