### PR TITLE
Add seller dashboard

### DIFF
--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+type ProductStatus = "available" | "pending" | "sold" | "removed";
+
+type ProductRow = {
+  product_id: string | number;
+  name: string;
+  price: number;
+  category: string | null;
+  image_url: string | null;
+  seller_id: string | null;
+  status: ProductStatus | null;
+  created_at: string | null;
+};
+
+const productStatuses = new Set<ProductStatus>([
+  "available",
+  "pending",
+  "sold",
+  "removed",
+]);
+
+function toProduct(row: ProductRow) {
+  return {
+    id: row.product_id,
+    name: row.name,
+    price: row.price,
+    category: row.category,
+    imageUrl: row.image_url,
+    sellerId: row.seller_id,
+    status: row.status ?? "available",
+    createdAt: row.created_at,
+  };
+}
+
+export async function GET() {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to view seller products." },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("products")
+      .select(
+        "product_id, name, price, category, image_url, seller_id, status, created_at"
+      )
+      .eq("seller_id", session.user.id)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ data: (data ?? []).map(toProduct) });
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to load seller products.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to update seller products." },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const productId = String(body.productId ?? "").trim();
+    const status = String(body.status ?? "").trim() as ProductStatus;
+
+    if (!productId || !productStatuses.has(status)) {
+      return NextResponse.json(
+        { message: "Product id and a valid status are required." },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("products")
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq("product_id", productId)
+      .eq("seller_id", session.user.id)
+      .select(
+        "product_id, name, price, category, image_url, seller_id, status, created_at"
+      )
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ product: toProduct(data) });
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to update seller product.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/app/api/seller/requests/route.ts
+++ b/app/api/seller/requests/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+type RequestStatus = "sent" | "accepted" | "declined" | "cancelled";
+
+type ProductRow = {
+  product_id: string | number;
+  name: string;
+  price: number;
+  image_url: string | null;
+};
+
+type RequestRow = {
+  request_id: string;
+  product_id: string;
+  buyer_id: string;
+  quantity: number;
+  note: string | null;
+  status: RequestStatus;
+  created_at: string;
+};
+
+const requestStatuses = new Set<RequestStatus>([
+  "sent",
+  "accepted",
+  "declined",
+  "cancelled",
+]);
+
+function toSellerRequest(row: RequestRow, product?: ProductRow) {
+  return {
+    id: row.request_id,
+    itemId: row.product_id,
+    buyerId: row.buyer_id,
+    quantity: row.quantity,
+    note: row.note ?? "",
+    status: row.status,
+    createdAt: row.created_at,
+    product: product
+      ? {
+          id: product.product_id,
+          name: product.name,
+          price: product.price,
+          imageUrl: product.image_url,
+        }
+      : null,
+  };
+}
+
+async function getSellerProducts(sellerId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("products")
+    .select("product_id, name, price, image_url")
+    .eq("seller_id", sellerId);
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? [];
+}
+
+export async function GET() {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to view seller requests." },
+        { status: 401 }
+      );
+    }
+
+    const products = await getSellerProducts(session.user.id);
+    const productIds = products.map((product) => String(product.product_id));
+
+    if (productIds.length === 0) {
+      return NextResponse.json({ data: [] });
+    }
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("trade_requests")
+      .select("request_id, product_id, buyer_id, quantity, note, status, created_at")
+      .in("product_id", productIds)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      throw error;
+    }
+
+    const productsById = new Map(
+      products.map((product) => [String(product.product_id), product])
+    );
+
+    return NextResponse.json({
+      data: (data ?? []).map((item) =>
+        toSellerRequest(item, productsById.get(String(item.product_id)))
+      ),
+    });
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to load seller requests.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to update seller requests." },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const requestId = String(body.requestId ?? "").trim();
+    const status = String(body.status ?? "").trim() as RequestStatus;
+
+    if (!requestId || !requestStatuses.has(status)) {
+      return NextResponse.json(
+        { message: "Request id and a valid status are required." },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createAdminClient();
+    const products = await getSellerProducts(session.user.id);
+    const productIds = new Set(
+      products.map((product) => String(product.product_id))
+    );
+
+    const { data: existing, error: lookupError } = await supabase
+      .from("trade_requests")
+      .select("request_id, product_id")
+      .eq("request_id", requestId)
+      .single();
+
+    if (lookupError) {
+      throw lookupError;
+    }
+
+    if (!productIds.has(String(existing.product_id))) {
+      return NextResponse.json(
+        { message: "Request not found for this seller." },
+        { status: 404 }
+      );
+    }
+
+    const { data, error } = await supabase
+      .from("trade_requests")
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq("request_id", requestId)
+      .select("request_id, product_id, buyer_id, quantity, note, status, created_at")
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    const product = products.find(
+      (item) => String(item.product_id) === String(data.product_id)
+    );
+
+    return NextResponse.json({ request: toSellerRequest(data, product) });
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to update seller request.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -55,6 +55,12 @@ export default function Header() {
           Sell
         </Link>
         <Link
+          href="/seller"
+          className="text-sm font-medium text-gray-700 hover:text-[#d73f09]"
+        >
+          Seller
+        </Link>
+        <Link
           href="/cart"
           className="flex items-center text-sm font-medium text-gray-700 hover:text-[#d73f09]"
         >

--- a/app/seller/page.tsx
+++ b/app/seller/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Badge, Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
+import { ArrowLeftIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+import Header from "../components/Header";
+
+type ProductStatus = "available" | "pending" | "sold" | "removed";
+type RequestStatus = "sent" | "accepted" | "declined" | "cancelled";
+
+type SellerProduct = {
+  id: string | number;
+  name: string;
+  price: number;
+  category?: string | null;
+  imageUrl?: string | null;
+  status: ProductStatus;
+};
+
+type SellerRequest = {
+  id: string;
+  itemId: string;
+  buyerId: string;
+  quantity: number;
+  note: string;
+  status: RequestStatus;
+  createdAt: string;
+  product: {
+    id: string | number;
+    name: string;
+    price: number;
+    imageUrl?: string | null;
+  } | null;
+};
+
+const currency = (n: number) =>
+  n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
+export default function SellerPage() {
+  const [products, setProducts] = useState<SellerProduct[]>([]);
+  const [requests, setRequests] = useState<SellerRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadSellerData() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [productsRes, requestsRes] = await Promise.all([
+        fetch("/api/seller/products", { cache: "no-store" }),
+        fetch("/api/seller/requests", { cache: "no-store" }),
+      ]);
+
+      if (!productsRes.ok || !requestsRes.ok) {
+        throw new Error("Failed to load seller dashboard.");
+      }
+
+      const productsPayload = await productsRes.json();
+      const requestsPayload = await requestsRes.json();
+
+      setProducts(productsPayload.data ?? []);
+      setRequests(requestsPayload.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load dashboard.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadSellerData();
+  }, []);
+
+  const pendingRequests = useMemo(
+    () => requests.filter((request) => request.status === "sent").length,
+    [requests]
+  );
+
+  async function updateRequest(requestId: string, status: RequestStatus) {
+    const res = await fetch("/api/seller/requests", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ requestId, status }),
+    });
+
+    if (res.ok) {
+      const payload = await res.json();
+      setRequests((current) =>
+        current.map((item) => (item.id === requestId ? payload.request : item))
+      );
+    }
+  }
+
+  async function updateProduct(productId: string | number, status: ProductStatus) {
+    const res = await fetch("/api/seller/products", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ productId, status }),
+    });
+
+    if (res.ok) {
+      const payload = await res.json();
+      setProducts((current) =>
+        current.map((item) => (item.id === productId ? payload.product : item))
+      );
+    }
+  }
+
+  return (
+    <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <main className="min-h-screen bg-gradient-to-br from-white via-[#fff1f1] to-[#ffe6e6] px-4 py-20">
+        <Header />
+
+        <section className="mx-auto max-w-7xl">
+          <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <Heading size="8" className="text-[#333]">
+                Seller Dashboard
+              </Heading>
+              <Text color="gray">
+                {products.length} listings, {pendingRequests} pending requests
+              </Text>
+            </div>
+
+            <div className="flex gap-3">
+              <Link href="/overview">
+                <Button variant="soft">
+                  <ArrowLeftIcon /> Marketplace
+                </Button>
+              </Link>
+              <Link href="/sell">
+                <Button highContrast>List Item</Button>
+              </Link>
+            </div>
+          </div>
+
+          {error && (
+            <p className="mb-4 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+
+          <div className="grid gap-6 lg:grid-cols-[1fr,1.1fr]">
+            <section>
+              <Heading size="5" className="mb-4">
+                My Listings
+              </Heading>
+              <div className="space-y-4">
+                {loading ? (
+                  <Card className="p-5">Loading listings...</Card>
+                ) : products.length === 0 ? (
+                  <Card className="p-5">
+                    <Text color="gray">No listings yet.</Text>
+                  </Card>
+                ) : (
+                  products.map((product) => (
+                    <ProductRow
+                      key={product.id}
+                      product={product}
+                      onStatus={(status) => updateProduct(product.id, status)}
+                    />
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section>
+              <Heading size="5" className="mb-4">
+                Buyer Requests
+              </Heading>
+              <div className="space-y-4">
+                {loading ? (
+                  <Card className="p-5">Loading requests...</Card>
+                ) : requests.length === 0 ? (
+                  <Card className="p-5">
+                    <Text color="gray">No buyer requests yet.</Text>
+                  </Card>
+                ) : (
+                  requests.map((request) => (
+                    <RequestRow
+                      key={request.id}
+                      request={request}
+                      onUpdate={(status) => updateRequest(request.id, status)}
+                    />
+                  ))
+                )}
+              </div>
+            </section>
+          </div>
+        </section>
+      </main>
+    </Theme>
+  );
+}
+
+function ProductRow({
+  product,
+  onStatus,
+}: {
+  product: SellerProduct;
+  onStatus: (status: ProductStatus) => void;
+}) {
+  return (
+    <Card className="border border-orange-200 bg-white/70 p-4 shadow">
+      <div className="flex gap-4">
+        <img
+          src={product.imageUrl || "/images/Bike_0.jpg"}
+          alt={product.name}
+          className="h-20 w-20 rounded-md object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <Text className="block font-medium">{product.name}</Text>
+              <Text color="gray" size="2">
+                {product.category || "general"} - {currency(product.price)}
+              </Text>
+            </div>
+            <StatusBadge status={product.status} />
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button
+              size="2"
+              variant="soft"
+              onClick={() => onStatus("available")}
+              disabled={product.status === "available"}
+            >
+              Available
+            </Button>
+            <Button
+              size="2"
+              variant="soft"
+              onClick={() => onStatus("pending")}
+              disabled={product.status === "pending"}
+            >
+              Pending
+            </Button>
+            <Button
+              size="2"
+              highContrast
+              onClick={() => onStatus("sold")}
+              disabled={product.status === "sold"}
+            >
+              Sold
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function RequestRow({
+  request,
+  onUpdate,
+}: {
+  request: SellerRequest;
+  onUpdate: (status: RequestStatus) => void;
+}) {
+  return (
+    <Card className="border border-orange-200 bg-white/70 p-4 shadow">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <Text className="block font-medium">
+            {request.product?.name || `Item ${request.itemId}`}
+          </Text>
+          <Text color="gray" size="2">
+            Qty {request.quantity} - Buyer {request.buyerId.slice(0, 8)}
+          </Text>
+        </div>
+        <StatusBadge status={request.status} />
+      </div>
+
+      {request.note && (
+        <p className="mt-3 rounded-md bg-orange-50 px-3 py-2 text-sm text-gray-700">
+          {request.note}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button
+          size="2"
+          highContrast
+          onClick={() => onUpdate("accepted")}
+          disabled={request.status === "accepted"}
+        >
+          <CheckIcon /> Accept
+        </Button>
+        <Button
+          size="2"
+          color="red"
+          variant="soft"
+          onClick={() => onUpdate("declined")}
+          disabled={request.status === "declined"}
+        >
+          <Cross2Icon /> Decline
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "accepted" || status === "available") {
+    return <Badge color="green">{status}</Badge>;
+  }
+  if (status === "declined" || status === "removed") {
+    return <Badge color="red">{status}</Badge>;
+  }
+  if (status === "sold") {
+    return <Badge color="blue">{status}</Badge>;
+  }
+  return <Badge color="amber">{status}</Badge>;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const { pathname, search } = req.nextUrl;
 
-  const protectedPrefixes = ["/overview"];
+  const protectedPrefixes = ["/overview", "/sell", "/cart", "/seller"];
   const isProtected = protectedPrefixes.some((prefix) =>
     pathname.startsWith(prefix)
   );
@@ -31,6 +31,9 @@ export default auth((req) => {
 export const config = {
   matcher: [
     "/overview/:path*",
+    "/sell/:path*",
+    "/cart/:path*",
+    "/seller/:path*",
     "/",
     "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
   ],


### PR DESCRIPTION
## Summary
- Add authenticated seller APIs for viewing/updating owned products and buyer requests.
- Add a `/seller` dashboard for sellers to manage listings, accept/decline requests, and mark product status.
- Add a Seller navigation link and protect seller/sell/cart routes in middleware.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- Local production smoke test: `/api/seller/products` and `/api/seller/requests` return `401` when anonymous.
- Local production smoke test: `/seller` redirects anonymous users to `/?from=%2Fseller`.

## Notes
- Authenticated seller data operations require the schema and `SUPABASE_SERVICE_ROLE_KEY` added in the previous MVP PRs.