### PR TITLE
Add buyer request history

### DIFF
--- a/app/api/requests/route.ts
+++ b/app/api/requests/route.ts
@@ -12,7 +12,15 @@ type RequestRow = {
   created_at: string;
 };
 
-function toRequest(row: RequestRow) {
+type ProductRow = {
+  product_id: string | number;
+  name: string;
+  price: number;
+  image_url: string | null;
+  seller_id: string | null;
+};
+
+function toRequest(row: RequestRow, product?: ProductRow, sellerEmail?: string) {
   return {
     id: row.request_id,
     itemId: row.product_id,
@@ -21,7 +29,98 @@ function toRequest(row: RequestRow) {
     note: row.note ?? "",
     status: row.status,
     createdAt: row.created_at,
+    sellerEmail: row.status === "accepted" ? sellerEmail ?? null : null,
+    product: product
+      ? {
+          id: product.product_id,
+          name: product.name,
+          price: product.price,
+          imageUrl: product.image_url,
+        }
+      : null,
   };
+}
+
+async function getEmailByUserId(userId: string | null | undefined) {
+  if (!userId) return null;
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.auth.admin.getUserById(userId);
+
+  if (error) {
+    throw error;
+  }
+
+  return data.user?.email ?? null;
+}
+
+export async function GET() {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to view your requests." },
+        { status: 401 }
+      );
+    }
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("trade_requests")
+      .select("request_id, product_id, buyer_id, quantity, note, status, created_at")
+      .eq("buyer_id", session.user.id)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      throw error;
+    }
+
+    const requests = data ?? [];
+    const productIds = requests.map((item) => String(item.product_id));
+    const { data: products, error: productError } = productIds.length
+      ? await supabase
+          .from("products")
+          .select("product_id, name, price, image_url, seller_id")
+          .in("product_id", productIds)
+      : { data: [], error: null };
+
+    if (productError) {
+      throw productError;
+    }
+
+    const productsById = new Map(
+      (products ?? []).map((product) => [String(product.product_id), product])
+    );
+    const sellerEmailById = new Map<string, string | null>();
+
+    for (const request of requests) {
+      if (request.status !== "accepted") continue;
+
+      const product = productsById.get(String(request.product_id));
+      const sellerId = product?.seller_id;
+
+      if (sellerId && !sellerEmailById.has(sellerId)) {
+        sellerEmailById.set(sellerId, await getEmailByUserId(sellerId));
+      }
+    }
+
+    return NextResponse.json({
+      data: requests.map((request) => {
+        const product = productsById.get(String(request.product_id));
+        const sellerEmail = product?.seller_id
+          ? sellerEmailById.get(product.seller_id)
+          : null;
+
+        return toRequest(request, product, sellerEmail ?? undefined);
+      }),
+    });
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to load requests.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
 }
 
 export async function POST(request: Request) {

--- a/app/api/seller/requests/route.ts
+++ b/app/api/seller/requests/route.ts
@@ -28,11 +28,29 @@ const requestStatuses = new Set<RequestStatus>([
   "cancelled",
 ]);
 
-function toSellerRequest(row: RequestRow, product?: ProductRow) {
+async function getEmailByUserId(userId: string | null | undefined) {
+  if (!userId) return null;
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.auth.admin.getUserById(userId);
+
+  if (error) {
+    throw error;
+  }
+
+  return data.user?.email ?? null;
+}
+
+function toSellerRequest(
+  row: RequestRow,
+  product?: ProductRow,
+  buyerEmail?: string | null
+) {
   return {
     id: row.request_id,
     itemId: row.product_id,
     buyerId: row.buyer_id,
+    buyerEmail: row.status === "accepted" ? buyerEmail ?? null : null,
     quantity: row.quantity,
     note: row.note ?? "",
     status: row.status,
@@ -94,10 +112,25 @@ export async function GET() {
     const productsById = new Map(
       products.map((product) => [String(product.product_id), product])
     );
+    const buyerEmailById = new Map<string, string | null>();
+
+    for (const request of data ?? []) {
+      if (request.status !== "accepted") continue;
+      if (!buyerEmailById.has(request.buyer_id)) {
+        buyerEmailById.set(
+          request.buyer_id,
+          await getEmailByUserId(request.buyer_id)
+        );
+      }
+    }
 
     return NextResponse.json({
       data: (data ?? []).map((item) =>
-        toSellerRequest(item, productsById.get(String(item.product_id)))
+        toSellerRequest(
+          item,
+          productsById.get(String(item.product_id)),
+          buyerEmailById.get(item.buyer_id)
+        )
       ),
     });
   } catch (error) {
@@ -167,8 +200,12 @@ export async function PATCH(request: Request) {
     const product = products.find(
       (item) => String(item.product_id) === String(data.product_id)
     );
+    const buyerEmail =
+      data.status === "accepted" ? await getEmailByUserId(data.buyer_id) : null;
 
-    return NextResponse.json({ request: toSellerRequest(data, product) });
+    return NextResponse.json({
+      request: toSellerRequest(data, product, buyerEmail),
+    });
   } catch (error) {
     console.error(error);
     const message =

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -61,6 +61,12 @@ export default function Header() {
           Seller
         </Link>
         <Link
+          href="/requests"
+          className="text-sm font-medium text-gray-700 hover:text-[#d73f09]"
+        >
+          Requests
+        </Link>
+        <Link
           href="/cart"
           className="flex items-center text-sm font-medium text-gray-700 hover:text-[#d73f09]"
         >

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Badge, Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
+import { ArrowLeftIcon } from "@radix-ui/react-icons";
+import Header from "../components/Header";
+
+type RequestStatus = "sent" | "accepted" | "declined" | "cancelled";
+
+type BuyerRequest = {
+  id: string;
+  itemId: string;
+  quantity: number;
+  note: string;
+  status: RequestStatus;
+  createdAt: string;
+  sellerEmail?: string | null;
+  product: {
+    id: string | number;
+    name: string;
+    price: number;
+    imageUrl?: string | null;
+  } | null;
+};
+
+const currency = (n: number) =>
+  n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
+export default function RequestsPage() {
+  const [requests, setRequests] = useState<BuyerRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/requests", { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error("Failed to load requests.");
+        }
+
+        return res.json();
+      })
+      .then((payload) => setRequests(payload.data ?? []))
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : "Failed to load requests.")
+      )
+      .finally(() => setLoading(false));
+  }, []);
+
+  const acceptedCount = useMemo(
+    () => requests.filter((request) => request.status === "accepted").length,
+    [requests]
+  );
+
+  return (
+    <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <main className="min-h-screen bg-gradient-to-br from-white via-[#fff1f1] to-[#ffe6e6] px-4 py-20">
+        <Header />
+
+        <section className="mx-auto max-w-5xl">
+          <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <Heading size="8" className="text-[#333]">
+                My Requests
+              </Heading>
+              <Text color="gray">
+                {requests.length} total, {acceptedCount} accepted
+              </Text>
+            </div>
+
+            <Link href="/overview">
+              <Button variant="soft">
+                <ArrowLeftIcon /> Marketplace
+              </Button>
+            </Link>
+          </div>
+
+          {error && (
+            <p className="mb-4 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+
+          <div className="space-y-4">
+            {loading ? (
+              <Card className="p-5">Loading requests...</Card>
+            ) : requests.length === 0 ? (
+              <Card className="p-8 text-center">
+                <Heading size="5" className="mb-2">
+                  No requests yet
+                </Heading>
+                <Text color="gray">
+                  Send a request from your cart to start a trade.
+                </Text>
+                <div className="mt-5">
+                  <Link href="/overview">
+                    <Button highContrast>Browse items</Button>
+                  </Link>
+                </div>
+              </Card>
+            ) : (
+              requests.map((request) => (
+                <RequestCard key={request.id} request={request} />
+              ))
+            )}
+          </div>
+        </section>
+      </main>
+    </Theme>
+  );
+}
+
+function RequestCard({ request }: { request: BuyerRequest }) {
+  return (
+    <Card className="border border-orange-200 bg-white/70 p-4 shadow">
+      <div className="flex gap-4">
+        <img
+          src={request.product?.imageUrl || "/images/Bike_0.jpg"}
+          alt={request.product?.name || `Item ${request.itemId}`}
+          className="h-24 w-24 rounded-md object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <Text className="block font-medium">
+                {request.product?.name || `Item ${request.itemId}`}
+              </Text>
+              <Text color="gray" size="2">
+                Qty {request.quantity}
+                {request.product ? ` - ${currency(request.product.price)}` : ""}
+              </Text>
+            </div>
+            <StatusBadge status={request.status} />
+          </div>
+
+          {request.note && (
+            <p className="mt-3 rounded-md bg-orange-50 px-3 py-2 text-sm text-gray-700">
+              {request.note}
+            </p>
+          )}
+
+          {request.status === "accepted" && request.sellerEmail ? (
+            <div className="mt-3 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">
+              Seller accepted. Contact:{" "}
+              <a className="font-medium underline" href={`mailto:${request.sellerEmail}`}>
+                {request.sellerEmail}
+              </a>
+            </div>
+          ) : (
+            <Text className="mt-3 block" color="gray" size="2">
+              Contact details appear after the seller accepts your request.
+            </Text>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function StatusBadge({ status }: { status: RequestStatus }) {
+  if (status === "accepted") return <Badge color="green">accepted</Badge>;
+  if (status === "declined" || status === "cancelled") {
+    return <Badge color="red">{status}</Badge>;
+  }
+  return <Badge color="amber">{status}</Badge>;
+}

--- a/app/seller/page.tsx
+++ b/app/seller/page.tsx
@@ -22,6 +22,7 @@ type SellerRequest = {
   id: string;
   itemId: string;
   buyerId: string;
+  buyerEmail?: string | null;
   quantity: number;
   note: string;
   status: RequestStatus;
@@ -278,6 +279,19 @@ function RequestRow({
         <p className="mt-3 rounded-md bg-orange-50 px-3 py-2 text-sm text-gray-700">
           {request.note}
         </p>
+      )}
+
+      {request.status === "accepted" && request.buyerEmail ? (
+        <div className="mt-3 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">
+          Buyer contact:{" "}
+          <a className="font-medium underline" href={`mailto:${request.buyerEmail}`}>
+            {request.buyerEmail}
+          </a>
+        </div>
+      ) : (
+        <Text className="mt-3 block" color="gray" size="2">
+          Buyer email appears after you accept the request.
+        </Text>
       )}
 
       <div className="mt-4 flex flex-wrap gap-2">

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,13 @@ export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const { pathname, search } = req.nextUrl;
 
-  const protectedPrefixes = ["/overview", "/sell", "/cart", "/seller"];
+  const protectedPrefixes = [
+    "/overview",
+    "/sell",
+    "/cart",
+    "/seller",
+    "/requests",
+  ];
   const isProtected = protectedPrefixes.some((prefix) =>
     pathname.startsWith(prefix)
   );
@@ -34,6 +40,7 @@ export const config = {
     "/sell/:path*",
     "/cart/:path*",
     "/seller/:path*",
+    "/requests/:path*",
     "/",
     "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
   ],


### PR DESCRIPTION
## Summary
- Add `GET /api/requests` so buyers can view their persisted trade requests.
- Add a `/requests` page and navigation link for buyer-side request history.
- Reveal seller email to the buyer only after a request is accepted, and reveal buyer email to the seller only after accepting.
- Protect the buyer requests page in middleware.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- Local production smoke test: anonymous `GET /api/requests` returns `401`.
- Local production smoke test: anonymous `/requests` redirects to `/?from=%2Frequests`.

## Notes
- Full authenticated end-to-end validation still depends on the Supabase schema and `SUPABASE_SERVICE_ROLE_KEY` being present in the deployed environment.