### PR TITLE
Add product image uploads

### DIFF
--- a/app/api/products/images/route.ts
+++ b/app/api/products/images/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+const bucketName = "product-images";
+const maxImageBytes = 5 * 1024 * 1024;
+const allowedTypes = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+function extensionFor(file: File) {
+  if (file.type === "image/png") return "png";
+  if (file.type === "image/webp") return "webp";
+  return "jpg";
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to upload product images." },
+        { status: 401 }
+      );
+    }
+
+    const formData = await request.formData();
+    const image = formData.get("image");
+
+    if (!(image instanceof File)) {
+      return NextResponse.json(
+        { message: "A product image file is required." },
+        { status: 400 }
+      );
+    }
+
+    if (!allowedTypes.has(image.type)) {
+      return NextResponse.json(
+        { message: "Only JPG, PNG, or WebP images are supported." },
+        { status: 400 }
+      );
+    }
+
+    if (image.size > maxImageBytes) {
+      return NextResponse.json(
+        { message: "Product images must be 5 MB or smaller." },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createAdminClient();
+    const objectPath = `${session.user.id}/${crypto.randomUUID()}.${extensionFor(
+      image
+    )}`;
+    const bytes = await image.arrayBuffer();
+
+    const { error } = await supabase.storage
+      .from(bucketName)
+      .upload(objectPath, bytes, {
+        cacheControl: "3600",
+        contentType: image.type,
+        upsert: false,
+      });
+
+    if (error) {
+      throw error;
+    }
+
+    const { data } = supabase.storage.from(bucketName).getPublicUrl(objectPath);
+
+    return NextResponse.json(
+      {
+        imageUrl: data.publicUrl,
+        path: objectPath,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to upload product image.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/app/sell/page.tsx
+++ b/app/sell/page.tsx
@@ -14,6 +14,7 @@ export default function SellPage() {
   const [price, setPrice] = useState("");
   const [category, setCategory] = useState("general");
   const [imageUrl, setImageUrl] = useState("");
+  const [imageFile, setImageFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,6 +23,28 @@ export default function SellPage() {
     setLoading(true);
     setError(null);
 
+    let nextImageUrl = imageUrl.trim();
+
+    if (imageFile) {
+      const uploadForm = new FormData();
+      uploadForm.append("image", imageFile);
+
+      const uploadRes = await fetch("/api/products/images", {
+        method: "POST",
+        body: uploadForm,
+      });
+
+      if (!uploadRes.ok) {
+        const payload = await uploadRes.json().catch(() => null);
+        setLoading(false);
+        setError(payload?.message || "Failed to upload image.");
+        return;
+      }
+
+      const uploadPayload = await uploadRes.json();
+      nextImageUrl = uploadPayload.imageUrl;
+    }
+
     const res = await fetch("/api/products", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -29,7 +52,7 @@ export default function SellPage() {
         name,
         price: Number(price),
         category,
-        imageUrl,
+        imageUrl: nextImageUrl,
       }),
     });
 
@@ -102,13 +125,29 @@ export default function SellPage() {
 
               <label className="block">
                 <Text as="span" size="2" weight="medium">
-                  Image URL
+                  Product image
+                </Text>
+                <input
+                  className="mt-2 w-full rounded-md border border-gray-300 bg-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  onChange={(event) => setImageFile(event.target.files?.[0] ?? null)}
+                />
+                <Text as="p" size="1" color="gray" className="mt-1">
+                  JPG, PNG, or WebP up to 5 MB.
+                </Text>
+              </label>
+
+              <label className="block">
+                <Text as="span" size="2" weight="medium">
+                  Image URL fallback
                 </Text>
                 <input
                   className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
                   type="url"
                   value={imageUrl}
                   onChange={(event) => setImageUrl(event.target.value)}
+                  disabled={!!imageFile}
                   placeholder="https://..."
                 />
               </label>

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["bmelflizqrhydlfuovnv.supabase.co"],
+    domains: [
+      "bmelflizqrhydlfuovnv.supabase.co",
+      "kigqkrmjzwqrxlpoukfb.supabase.co",
+    ],
   },
 };
 

--- a/supabase/mvp-schema.sql
+++ b/supabase/mvp-schema.sql
@@ -1,5 +1,9 @@
 create extension if not exists pgcrypto;
 
+insert into storage.buckets (id, name, public)
+values ('product-images', 'product-images', true)
+on conflict (id) do update set public = excluded.public;
+
 alter table public.products
   add column if not exists seller_id uuid references auth.users(id) on delete set null,
   add column if not exists status text not null default 'available' check (status in ('available', 'pending', 'sold', 'removed')),


### PR DESCRIPTION
## Summary
- Add an authenticated `POST /api/products/images` endpoint that uploads JPG, PNG, or WebP images to Supabase Storage.
- Update the sell form to support direct image file upload before listing an item, while preserving the image URL fallback.
- Add the new Supabase project image host to Next.js config.
- Extend the MVP Supabase schema to create a public `product-images` storage bucket.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- Local production smoke test: anonymous `POST /api/products/images` returns `401`.

## Notes
- Apply the updated `supabase/mvp-schema.sql` so the `product-images` bucket exists before authenticated upload validation.