### PR TITLE
Allow non-OSU email signup

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -8,11 +8,11 @@ export async function POST(request: Request) {
     const normalizedEmail = String(email ?? "").trim().toLowerCase();
     const normalizedUsername = String(username ?? "").trim();
 
-    if (!normalizedEmail.endsWith("@oregonstate.edu")) {
+    if (!normalizedEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
       return NextResponse.json(
         {
-          errorCode: "EMAIL_DOMAIN_INVALID",
-          message: "Only @oregonstate.edu emails are allowed.",
+          errorCode: "EMAIL_INVALID",
+          message: "Please enter a valid email address.",
         },
         { status: 400 }
       );
@@ -97,7 +97,7 @@ export async function POST(request: Request) {
           status: "confirmation_required",
           email: normalizedEmail,
           name: normalizedUsername,
-          message: "Please check your OSU email to confirm your account.",
+          message: "Please check your email to confirm your account.",
         },
         { status: 202 }
       );

--- a/app/components/SignUpModal.tsx
+++ b/app/components/SignUpModal.tsx
@@ -36,13 +36,13 @@ export default function SignUpModal() {
 
     if (!res.ok && res.status !== 202) {
       setLoading(false);
-      setError(payload.message || "Sign up failed. Check your OSU email and password.");
+      setError(payload.message || "Sign up failed. Check your email and password.");
       return;
     }
 
     if (res.status === 202 || payload.status === "confirmation_required") {
       setLoading(false);
-      setSuccess(payload.message || "Please check your OSU email to confirm your account.");
+      setSuccess(payload.message || "Please check your email to confirm your account.");
       return;
     }
 
@@ -55,7 +55,7 @@ export default function SignUpModal() {
     setLoading(false);
 
     if (loginResult?.error) {
-      setSuccess("Account created. Please log in after confirming your OSU email.");
+      setSuccess("Account created. Please log in after confirming your email.");
       return;
     }
 


### PR DESCRIPTION
## Summary
- Remove the `@oregonstate.edu` domain restriction from signup.
- Keep basic email format validation before creating a Supabase Auth user.
- Update signup UI messages so they refer to a generic email inbox instead of an OSU email inbox.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- Local production smoke test: invalid email returns `EMAIL_INVALID`.
- Local production smoke test: non-OSU email with missing fields reaches normal field validation instead of domain rejection.

## Notes
- This makes it possible to test registration with non-school inboxes if OSU blocks confirmation delivery.