### PR TITLE
Tighten request status workflow

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -44,7 +44,8 @@ export async function GET(request: NextRequest) {
       .from("products")
       .select("product_id, name, price, category, image_url, seller_id, status", {
         count: "exact",
-      });
+      })
+      .eq("status", "available");
 
     if (name) {
       query = query.ilike("name", `%${name}%`);

--- a/app/api/requests/route.ts
+++ b/app/api/requests/route.ts
@@ -18,6 +18,7 @@ type ProductRow = {
   price: number;
   image_url: string | null;
   seller_id: string | null;
+  status?: string | null;
 };
 
 function toRequest(row: RequestRow, product?: ProductRow, sellerEmail?: string) {
@@ -123,6 +124,68 @@ export async function GET() {
   }
 }
 
+export async function PATCH(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { message: "You must be logged in to update your requests." },
+        { status: 401 }
+      );
+    }
+
+    const body = await request.json();
+    const requestId = String(body.requestId ?? "").trim();
+    const status = String(body.status ?? "").trim();
+
+    if (!requestId || status !== "cancelled") {
+      return NextResponse.json(
+        { message: "Request id and cancelled status are required." },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createAdminClient();
+    const { data: existing, error: lookupError } = await supabase
+      .from("trade_requests")
+      .select("request_id, buyer_id, status")
+      .eq("request_id", requestId)
+      .eq("buyer_id", session.user.id)
+      .single();
+
+    if (lookupError) {
+      throw lookupError;
+    }
+
+    if (existing.status !== "sent") {
+      return NextResponse.json(
+        { message: "Only pending requests can be cancelled." },
+        { status: 409 }
+      );
+    }
+
+    const { data, error } = await supabase
+      .from("trade_requests")
+      .update({ status: "cancelled", updated_at: new Date().toISOString() })
+      .eq("request_id", requestId)
+      .eq("buyer_id", session.user.id)
+      .select("request_id, product_id, buyer_id, quantity, note, status, created_at")
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ request: toRequest(data) });
+  } catch (error) {
+    console.error(error);
+    const message =
+      error instanceof Error ? error.message : "Failed to update request.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}
+
 export async function POST(request: Request) {
   try {
     const session = await auth();
@@ -147,6 +210,30 @@ export async function POST(request: Request) {
     }
 
     const supabase = createAdminClient();
+    const { data: product, error: productError } = await supabase
+      .from("products")
+      .select("product_id, seller_id, status")
+      .eq("product_id", itemId)
+      .single();
+
+    if (productError) {
+      throw productError;
+    }
+
+    if (product.seller_id === session.user.id) {
+      return NextResponse.json(
+        { message: "You cannot request your own listing." },
+        { status: 409 }
+      );
+    }
+
+    if (product.status !== "available") {
+      return NextResponse.json(
+        { message: "This item is no longer available for requests." },
+        { status: 409 }
+      );
+    }
+
     const { data, error } = await supabase
       .from("trade_requests")
       .insert({

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -105,6 +105,14 @@ export async function PATCH(request: Request) {
       throw error;
     }
 
+    if (status === "sold") {
+      await supabase
+        .from("trade_requests")
+        .update({ status: "declined", updated_at: new Date().toISOString() })
+        .eq("product_id", productId)
+        .eq("status", "sent");
+    }
+
     return NextResponse.json({ product: toProduct(data) });
   } catch (error) {
     console.error(error);

--- a/app/api/seller/requests/route.ts
+++ b/app/api/seller/requests/route.ts
@@ -200,6 +200,15 @@ export async function PATCH(request: Request) {
     const product = products.find(
       (item) => String(item.product_id) === String(data.product_id)
     );
+
+    if (status === "accepted") {
+      await supabase
+        .from("products")
+        .update({ status: "pending", updated_at: new Date().toISOString() })
+        .eq("product_id", data.product_id)
+        .eq("seller_id", session.user.id);
+    }
+
     const buyerEmail =
       data.status === "accepted" ? await getEmailByUserId(data.buyer_id) : null;
 

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -48,6 +48,21 @@ export default function RequestsPage() {
       .finally(() => setLoading(false));
   }, []);
 
+  async function cancelRequest(requestId: string) {
+    const res = await fetch("/api/requests", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ requestId, status: "cancelled" }),
+    });
+
+    if (res.ok) {
+      const payload = await res.json();
+      setRequests((current) =>
+        current.map((item) => (item.id === requestId ? payload.request : item))
+      );
+    }
+  }
+
   const acceptedCount = useMemo(
     () => requests.filter((request) => request.status === "accepted").length,
     [requests]
@@ -101,7 +116,11 @@ export default function RequestsPage() {
               </Card>
             ) : (
               requests.map((request) => (
-                <RequestCard key={request.id} request={request} />
+                <RequestCard
+                  key={request.id}
+                  request={request}
+                  onCancel={() => cancelRequest(request.id)}
+                />
               ))
             )}
           </div>
@@ -111,7 +130,13 @@ export default function RequestsPage() {
   );
 }
 
-function RequestCard({ request }: { request: BuyerRequest }) {
+function RequestCard({
+  request,
+  onCancel,
+}: {
+  request: BuyerRequest;
+  onCancel: () => void;
+}) {
   return (
     <Card className="border border-orange-200 bg-white/70 p-4 shadow">
       <div className="flex gap-4">
@@ -151,6 +176,12 @@ function RequestCard({ request }: { request: BuyerRequest }) {
             <Text className="mt-3 block" color="gray" size="2">
               Contact details appear after the seller accepts your request.
             </Text>
+          )}
+
+          {request.status === "sent" && (
+            <Button className="mt-4" color="red" variant="soft" onClick={onCancel}>
+              Cancel request
+            </Button>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Only show available products in the public marketplace list.
- Prevent buyers from requesting their own listings or unavailable products.
- Let buyers cancel their own pending requests from `/requests`.
- Mark a product as `pending` when a seller accepts a request.
- Decline remaining pending requests when a seller marks a product as sold.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- Local production smoke test: anonymous `PATCH /api/requests` returns `401`.

## Notes
- Full authenticated workflow validation depends on the deployed Supabase schema and service role key being configured.