### PR TITLE
Add signup profile schema

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { createAdminClient } from "@/utils/supabase/admin";
 import { createClient } from "@/utils/supabase/server";
 
 export async function POST(request: Request) {
@@ -28,10 +29,11 @@ export async function POST(request: Request) {
       );
     }
 
-    const { data: existingUser, error: userLookupError } = await supabase
+    const admin = createAdminClient();
+    const { data: existingUser, error: userLookupError } = await admin
       .from("users")
       .select("name")
-      .eq("name", normalizedUsername)
+      .ilike("name", normalizedUsername)
       .maybeSingle();
 
     if (userLookupError) {
@@ -103,15 +105,32 @@ export async function POST(request: Request) {
       );
     }
 
+    const displayName =
+      u.user_metadata?.name ??
+      u.user_metadata?.full_name ??
+      u.email?.split("@")[0] ??
+      normalizedUsername;
+
+    const { error: profileError } = await admin.from("users").upsert(
+      {
+        id: u.id,
+        email: u.email ?? normalizedEmail,
+        name: displayName,
+        role: u.user_metadata?.role ?? "user",
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "id" }
+    );
+
+    if (profileError) {
+      throw profileError;
+    }
+
     return NextResponse.json(
       {
         id: u.id,
         email: u.email,
-        name:
-          u.user_metadata?.name ??
-          u.user_metadata?.full_name ??
-          u.email?.split("@")[0] ??
-          "User",
+        name: displayName,
         role: u.user_metadata?.role ?? "user",
       },
       { status: 200 }

--- a/supabase/mvp-schema.sql
+++ b/supabase/mvp-schema.sql
@@ -1,5 +1,44 @@
 create extension if not exists pgcrypto;
 
+create table if not exists public.users (
+  id uuid primary key references auth.users(id) on delete cascade,
+  email text not null unique,
+  name text not null unique,
+  role text not null default 'user',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.users
+  add column if not exists email text,
+  add column if not exists name text,
+  add column if not exists role text not null default 'user',
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists updated_at timestamptz not null default now();
+
+create unique index if not exists users_email_unique_idx
+  on public.users (lower(email));
+
+create unique index if not exists users_name_unique_idx
+  on public.users (lower(name));
+
+alter table public.users enable row level security;
+
+drop policy if exists "Users can read their profile" on public.users;
+create policy "Users can read their profile"
+  on public.users
+  for select
+  to authenticated
+  using (id = auth.uid());
+
+drop policy if exists "Users can update their profile" on public.users;
+create policy "Users can update their profile"
+  on public.users
+  for update
+  to authenticated
+  using (id = auth.uid())
+  with check (id = auth.uid());
+
 insert into storage.buckets (id, name, public)
 values ('product-images', 'product-images', true)
 on conflict (id) do update set public = excluded.public;


### PR DESCRIPTION
## Summary
- add the missing `public.users` profile table to the Supabase MVP schema
- add RLS policies for users to read/update their own profile
- make signup use the admin client for username lookup and profile upsert after Supabase Auth signup

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- local production smoke: invalid signup returned 400 and `/api/products?limit=1` returned 200