### PR TITLE
Add bilingual UI language toggle

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -17,6 +17,7 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@radix-ui/react-icons";
+import { useI18n } from "../i18n";
 
 type CartItem = {
   id: string;
@@ -45,6 +46,7 @@ async function saveCart(items: CartItem[]) {
 }
 
 export default function CartPage() {
+  const { t } = useI18n();
   const [items, setItems] = useState<CartItem[]>([]);
   const [states, setStates] = useState<Record<string, ItemState>>({});
   const [loading, setLoading] = useState(true);
@@ -132,7 +134,7 @@ export default function CartPage() {
         [id]: {
           ...prev[id],
           status: "error",
-          errorMsg: payload?.message || "Failed to send request.",
+          errorMsg: payload?.message || t("cart.sendFailed"),
         },
       }));
       return;
@@ -155,12 +157,12 @@ export default function CartPage() {
         <div className="mx-auto max-w-7xl">
           <div className="mb-8 flex items-center justify-between">
             <Heading size="8" className="text-[#333]">
-              Your Requests
+              {t("cart.title")}
             </Heading>
 
             <Link href="/overview" className="inline-flex items-center gap-2">
               <Button variant="soft">
-                <ArrowLeftIcon /> Back to Marketplace
+                <ArrowLeftIcon /> {t("cart.backMarketplace")}
               </Button>
             </Link>
           </div>
@@ -169,19 +171,19 @@ export default function CartPage() {
             <section className="space-y-4">
               {loading ? (
                 <Card className="border border-orange-200 bg-white/60 p-6 shadow">
-                  <Text>Loading your cart...</Text>
+                  <Text>{t("cart.loading")}</Text>
                 </Card>
               ) : items.length === 0 ? (
                 <Card className="border border-orange-200 bg-white/60 p-8 text-center shadow">
                   <Heading size="5" className="mb-2">
-                    Your cart is empty
+                    {t("cart.empty")}
                   </Heading>
                   <Text color="gray">
-                    Add items in Marketplace and send requests to sellers.
+                    {t("cart.emptyHelp")}
                   </Text>
                   <div className="mt-6">
                     <Link href="/overview">
-                      <Button highContrast>Go shopping</Button>
+                      <Button highContrast>{t("cart.goShopping")}</Button>
                     </Link>
                   </div>
                 </Card>
@@ -196,6 +198,7 @@ export default function CartPage() {
                     onMinus={() => changeQty(item.id, -1)}
                     onPlus={() => changeQty(item.id, 1)}
                     onSend={() => sendRequest(item.id)}
+                    t={t}
                   />
                 ))
               )}
@@ -204,18 +207,18 @@ export default function CartPage() {
             <aside>
               <Card className="rounded-2xl border border-orange-200 bg-white/70 p-6 shadow">
                 <Heading size="5" className="mb-4">
-                  Request Summary
+                  {t("cart.summary")}
                 </Heading>
 
                 <div className="space-y-2">
-                  <SummaryRow label="Items" value={String(items.length)} />
-                  <SummaryRow label="Subtotal" value={currency(subtotal)} />
+                  <SummaryRow label={t("cart.items")} value={String(items.length)} />
+                  <SummaryRow label={t("cart.subtotal")} value={currency(subtotal)} />
                   <SummaryRow
-                    label="Pending / Total"
+                    label={t("cart.pendingTotal")}
                     value={`${pendingCount} / ${items.length}`}
                   />
-                  <SummaryRow label="Sent" value={String(sentCount)} />
-                  <SummaryRow label="Failed" value={String(errorCount)} />
+                  <SummaryRow label={t("cart.sent")} value={String(sentCount)} />
+                  <SummaryRow label={t("cart.failed")} value={String(errorCount)} />
                 </div>
 
                 <Separator my="3" size="4" />
@@ -227,7 +230,7 @@ export default function CartPage() {
                   onClick={sendAll}
                   disabled={items.length === 0}
                 >
-                  Send all requests
+                  {t("cart.sendAll")}
                 </Button>
               </Card>
             </aside>
@@ -246,6 +249,7 @@ function ItemCard({
   onMinus,
   onPlus,
   onSend,
+  t,
 }: {
   item: CartItem;
   state?: ItemState;
@@ -254,6 +258,7 @@ function ItemCard({
   onMinus: () => void;
   onPlus: () => void;
   onSend: () => void;
+  t: ReturnType<typeof useI18n>["t"];
 }) {
   const disabled = state?.status === "sending";
 
@@ -282,10 +287,10 @@ function ItemCard({
             <button
               onClick={onRemove}
               className="inline-flex items-center gap-1 text-red-600 transition-colors hover:text-red-700"
-              aria-label="Remove item"
-              title="Remove item"
+              aria-label={t("cart.remove")}
+              title={t("cart.remove")}
             >
-              <TrashIcon /> <span className="text-sm">Remove</span>
+              <TrashIcon /> <span className="text-sm">{t("cart.remove")}</span>
             </button>
           </div>
 
@@ -294,7 +299,7 @@ function ItemCard({
               <button
                 onClick={onMinus}
                 className="p-2 transition hover:bg-gray-50 active:scale-95"
-                aria-label="Decrease quantity"
+                aria-label={t("cart.decrease")}
               >
                 <MinusIcon />
               </button>
@@ -302,7 +307,7 @@ function ItemCard({
               <button
                 onClick={onPlus}
                 className="p-2 transition hover:bg-gray-50 active:scale-95"
-                aria-label="Increase quantity"
+                aria-label={t("cart.increase")}
               >
                 <PlusIcon />
               </button>
@@ -316,13 +321,13 @@ function ItemCard({
           <div className="mt-4 grid gap-2 sm:grid-cols-[1fr,auto] sm:items-end">
             <div>
               <label className="mb-1 block text-sm font-medium text-gray-700">
-                Note to seller
+                {t("cart.note")}
               </label>
               <textarea
                 rows={2}
                 value={state?.note ?? ""}
                 onChange={(event) => onNote(event.target.value)}
-                placeholder="e.g., Can we meet at the library?"
+                placeholder={t("cart.notePlaceholder")}
                 className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
                 disabled={disabled}
               />
@@ -342,10 +347,10 @@ function ItemCard({
               onClick={onSend}
             >
               {state?.status === "sending"
-                ? "Sending..."
+                ? t("cart.sending")
                 : state?.status === "sent"
-                  ? "Sent"
-                  : "Send request"}
+                  ? t("cart.sent")
+                  : t("cart.send")}
             </Button>
           </div>
         </div>
@@ -355,10 +360,12 @@ function ItemCard({
 }
 
 function StatusBadge({ status }: { status: ItemState["status"] }) {
-  if (status === "sending") return <Badge color="amber">Sending</Badge>;
-  if (status === "sent") return <Badge color="green">Sent</Badge>;
-  if (status === "error") return <Badge color="red">Error</Badge>;
-  return <Badge color="gray">Idle</Badge>;
+  const { t } = useI18n();
+
+  if (status === "sending") return <Badge color="amber">{t("cart.sending")}</Badge>;
+  if (status === "sent") return <Badge color="green">{t("cart.sent")}</Badge>;
+  if (status === "error") return <Badge color="red">{t("cart.error")}</Badge>;
+  return <Badge color="gray">{t("cart.idle")}</Badge>;
 }
 
 function SummaryRow({ label, value }: { label: string; value: string }) {

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -7,6 +7,7 @@ import { signOut, getSession } from "next-auth/react";
 import { Avatar, DropdownMenu } from "@radix-ui/themes";
 import { RocketIcon } from "@radix-ui/react-icons";
 import LoginModal from "./LoginModal";
+import { LanguageToggle, useI18n } from "../i18n";
 
 type HeaderUser = {
   name?: string | null;
@@ -14,6 +15,7 @@ type HeaderUser = {
 };
 
 export default function Header() {
+  const { t } = useI18n();
   const [user, setUser] = useState<HeaderUser | null>(null);
 
   useEffect(() => {
@@ -40,23 +42,24 @@ export default function Header() {
 
         <nav className="flex flex-wrap items-center justify-end gap-1 sm:gap-2">
           <Link href="/" className={navLinkClass}>
-            Home
+            {t("nav.home")}
           </Link>
           <Link href="/overview" className={navLinkClass}>
-            Marketplace
+            {t("nav.marketplace")}
           </Link>
           <Link href="/sell" className={navLinkClass}>
-            Sell
+            {t("nav.sell")}
           </Link>
           <Link href="/seller" className={navLinkClass}>
-            Seller
+            {t("nav.seller")}
           </Link>
           <Link href="/requests" className={navLinkClass}>
-            Requests
+            {t("nav.requests")}
           </Link>
           <Link href="/cart" className={`${navLinkClass} inline-flex items-center`}>
-            <RocketIcon className="mr-1" /> Cart
+            <RocketIcon className="mr-1" /> {t("nav.cart")}
           </Link>
+          <LanguageToggle />
 
           {!user ? (
             <LoginModal />
@@ -75,7 +78,7 @@ export default function Header() {
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator />
                 <DropdownMenu.Item color="red" onClick={() => signOut()}>
-                  Logout
+                  {t("nav.logout")}
                 </DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu.Root>

--- a/app/components/LoginModal.tsx
+++ b/app/components/LoginModal.tsx
@@ -4,8 +4,10 @@ import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { Dialog, Flex, Button } from "@radix-ui/themes";
+import { useI18n } from "../i18n";
 
 export default function LoginModal() {
+  const { t } = useI18n();
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [email, setEmail] = useState("");
@@ -27,7 +29,7 @@ export default function LoginModal() {
     setLoading(false);
 
     if (result?.error) {
-      setError("The email or password is incorrect.");
+      setError(t("auth.loginError"));
       return;
     }
 
@@ -44,16 +46,16 @@ export default function LoginModal() {
         className="border-[#d73f09] text-[#d73f09]"
         onClick={() => setIsOpen(true)}
       >
-        Login
+        {t("auth.login")}
       </Button>
       <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
         <Dialog.Content maxWidth="450px">
-          <Dialog.Title>Login</Dialog.Title>
+          <Dialog.Title>{t("auth.login")}</Dialog.Title>
           <form onSubmit={onSubmit}>
             <Flex direction="column" gap="3" mt="4">
               <input
                 className="px-3 py-2 border rounded"
-                placeholder="Email"
+                placeholder={t("auth.email")}
                 type="email"
                 autoComplete="email"
                 value={email}
@@ -63,7 +65,7 @@ export default function LoginModal() {
               <input
                 type="password"
                 className="px-3 py-2 border rounded"
-                placeholder="Password"
+                placeholder={t("auth.password")}
                 autoComplete="current-password"
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
@@ -75,7 +77,7 @@ export default function LoginModal() {
                 </p>
               )}
               <Button highContrast type="submit" disabled={loading}>
-                {loading ? "Logging in..." : "Login"}
+                {loading ? t("auth.loggingIn") : t("auth.login")}
               </Button>
             </Flex>
           </form>

--- a/app/components/ProductCard.tsx
+++ b/app/components/ProductCard.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Card, Text, Heading, Button } from "@radix-ui/themes";
 import { PlusIcon } from "@radix-ui/react-icons";
+import { useI18n } from "../i18n";
 
 interface ProductCardProps {
   productId: string | number;
@@ -20,6 +21,7 @@ export default function ProductCard({
   price,
   imageUrl,
 }: ProductCardProps) {
+  const { t } = useI18n();
   const [adding, setAdding] = useState(false);
   const [feedback, setFeedback] = useState<{
     tone: "success" | "error";
@@ -45,12 +47,12 @@ export default function ProductCard({
       }
       setFeedback({
         tone: "success",
-        message: "Added to request cart.",
+        message: t("product.added"),
       });
     } catch {
       setFeedback({
         tone: "error",
-        message: "Could not add item. Please try again.",
+        message: t("product.addError"),
       });
     } finally {
       setAdding(false);
@@ -76,7 +78,7 @@ export default function ProductCard({
             onClick={addToCart}
             disabled={adding}
           >
-            <PlusIcon /> <span>{adding ? "Adding..." : "Add to cart"}</span>
+            <PlusIcon /> <span>{adding ? t("product.adding") : t("product.addToCart")}</span>
           </Button>
           <Text size="3" weight="medium" className="text-gray-700">
             ${price}

--- a/app/components/ProductListCard.tsx
+++ b/app/components/ProductListCard.tsx
@@ -2,12 +2,15 @@
 "use client";
 
 import { Card, Heading } from "@radix-ui/themes";
+import { useI18n } from "../i18n";
 
 export default function ProductListCard() {
+  const { t } = useI18n();
+
   return (
     <Card className="bg-white/70 backdrop-blur-md p-4 border border-orange-300 shadow hover:scale-[1.02] transition-transform">
       <Heading size="5" mb="3">
-        On Sell Products
+        {t("home.onSale")}
       </Heading>
       <ul className="text-sm text-gray-700 space-y-2">
         <li>

--- a/app/components/SignUpModal.tsx
+++ b/app/components/SignUpModal.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useState } from "react";
 import { signIn } from "next-auth/react";
 import { Dialog, Flex, Button } from "@radix-ui/themes";
+import { useI18n } from "../i18n";
 
 type SignupResponse = {
   id?: string;
@@ -13,6 +14,7 @@ type SignupResponse = {
 };
 
 export default function SignUpModal() {
+  const { t } = useI18n();
   const [isOpen, setIsOpen] = useState(false);
   const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
@@ -36,13 +38,13 @@ export default function SignUpModal() {
 
     if (!res.ok && res.status !== 202) {
       setLoading(false);
-      setError(payload.message || "Sign up failed. Check your email and password.");
+      setError(payload.message || t("auth.signupError"));
       return;
     }
 
     if (res.status === 202 || payload.status === "confirmation_required") {
       setLoading(false);
-      setSuccess(payload.message || "Please check your email to confirm your account.");
+      setSuccess(payload.message || t("auth.confirmEmail"));
       return;
     }
 
@@ -55,7 +57,7 @@ export default function SignUpModal() {
     setLoading(false);
 
     if (loginResult?.error) {
-      setSuccess("Account created. Please log in after confirming your email.");
+      setSuccess(t("auth.createdConfirm"));
       return;
     }
 
@@ -70,18 +72,18 @@ export default function SignUpModal() {
         className="bg-[#1a1a1a] text-white hover:bg-[#333]"
         onClick={() => setIsOpen(true)}
       >
-        Sign Up
+        {t("auth.signup")}
       </Button>
 
       <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
         <Dialog.Content maxWidth="450px">
-          <Dialog.Title>Sign Up</Dialog.Title>
+          <Dialog.Title>{t("auth.signup")}</Dialog.Title>
 
           <form onSubmit={onSubmit}>
             <Flex direction="column" gap="3" mt="4">
               <input
                 className="px-3 py-2 border rounded"
-                placeholder="Email"
+                placeholder={t("auth.email")}
                 type="email"
                 autoComplete="email"
                 value={email}
@@ -90,7 +92,7 @@ export default function SignUpModal() {
               />
               <input
                 className="px-3 py-2 border rounded"
-                placeholder="User Name"
+                placeholder={t("auth.username")}
                 autoComplete="name"
                 value={username}
                 onChange={(event) => setUsername(event.target.value)}
@@ -99,7 +101,7 @@ export default function SignUpModal() {
               <input
                 type="password"
                 className="px-3 py-2 border rounded"
-                placeholder="Password"
+                placeholder={t("auth.password")}
                 autoComplete="new-password"
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
@@ -119,7 +121,7 @@ export default function SignUpModal() {
               )}
 
               <Button highContrast type="submit" disabled={loading}>
-                {loading ? "Creating account..." : "Sign Up"}
+                {loading ? t("auth.creating") : t("auth.signup")}
               </Button>
             </Flex>
           </form>

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+const dictionaries = {
+  en: {
+    "common.language": "Language",
+    "common.english": "EN",
+    "common.zhTw": "繁中",
+    "common.loading": "Loading...",
+    "common.refresh": "Refresh",
+    "common.refreshing": "Refreshing...",
+    "common.clear": "Clear",
+    "common.category.general": "general",
+    "common.category.electronics": "electronics",
+    "common.category.clothing": "clothing",
+    "common.category.books": "books",
+    "common.category.home": "home",
+    "nav.home": "Home",
+    "nav.marketplace": "Marketplace",
+    "nav.sell": "Sell",
+    "nav.seller": "Seller",
+    "nav.requests": "Requests",
+    "nav.cart": "Cart",
+    "nav.logout": "Logout",
+    "auth.login": "Login",
+    "auth.signup": "Sign Up",
+    "auth.email": "Email",
+    "auth.password": "Password",
+    "auth.username": "User Name",
+    "auth.loggingIn": "Logging in...",
+    "auth.creating": "Creating account...",
+    "auth.loginError": "The email or password is incorrect.",
+    "auth.signupError": "Sign up failed. Check your email and password.",
+    "auth.confirmEmail": "Please check your email to confirm your account.",
+    "auth.createdConfirm": "Account created. Please log in after confirming your email.",
+    "home.description":
+      "Looking to declutter or find great deals? OSUTrade helps you list secondhand items, browse campus listings, and send requests to sellers in a few clicks.",
+    "home.github": "GitHub",
+    "home.discord": "Discord",
+    "home.support": "Support Us",
+    "home.about": "About Us",
+    "home.onSale": "On Sale Products",
+    "marketplace.title": "Find campus deals faster.",
+    "marketplace.subtitle":
+      "Browse available listings, filter by category, and add items to your request cart when you are ready to contact the seller.",
+    "marketplace.listItem": "List Item",
+    "marketplace.loadError": "Failed to load products: {message}",
+    "marketplace.search": "Search",
+    "marketplace.searchPlaceholder": "Search by item name",
+    "marketplace.category": "Category",
+    "marketplace.allCategories": "All categories",
+    "marketplace.sort": "Sort",
+    "marketplace.newest": "Newest first",
+    "marketplace.priceAsc": "Price: low to high",
+    "marketplace.priceDesc": "Price: high to low",
+    "marketplace.showing": "Showing {shown} of {total} listings",
+    "marketplace.loadingListings": "Loading listings...",
+    "marketplace.noMatches": "No matching listings",
+    "marketplace.noMatchesHelp": "Try clearing filters or list the first item in this category.",
+    "product.addToCart": "Add to request cart",
+    "product.adding": "Adding...",
+    "product.added": "Added to request cart.",
+    "product.addedDetail": "Added to request cart. You can review it before sending.",
+    "product.addError": "Could not add item. Please try again.",
+    "product.addErrorDetail": "Could not add this item. Please try again.",
+    "product.backMarketplace": "Back to marketplace",
+    "product.loading": "Loading item...",
+    "product.unavailable": "Product unavailable",
+    "product.notFound": "This item was not found.",
+    "product.seller": "Seller",
+    "product.contactAfterRequest": "Contact is handled after you send a request.",
+    "product.stepCart": "Add the item to your request cart, then send one request with notes.",
+    "product.stepSeller": "The seller can accept or decline from their seller dashboard.",
+    "product.statusUnavailable": "Unavailable",
+    "sell.title": "List an Item",
+    "sell.itemName": "Item name",
+    "sell.price": "Price",
+    "sell.productImage": "Product image",
+    "sell.imageHelp": "JPG, PNG, or WebP up to 5 MB.",
+    "sell.imageUrlFallback": "Image URL fallback",
+    "sell.listing": "Listing...",
+    "sell.submit": "List item",
+    "sell.uploadError": "Failed to upload image.",
+    "sell.listError": "Failed to list item.",
+    "cart.title": "Your Requests",
+    "cart.backMarketplace": "Back to Marketplace",
+    "cart.loading": "Loading your cart...",
+    "cart.empty": "Your cart is empty",
+    "cart.emptyHelp": "Add items in Marketplace and send requests to sellers.",
+    "cart.goShopping": "Go shopping",
+    "cart.summary": "Request Summary",
+    "cart.items": "Items",
+    "cart.subtotal": "Subtotal",
+    "cart.pendingTotal": "Pending / Total",
+    "cart.sent": "Sent",
+    "cart.failed": "Failed",
+    "cart.sendAll": "Send all requests",
+    "cart.remove": "Remove",
+    "cart.decrease": "Decrease quantity",
+    "cart.increase": "Increase quantity",
+    "cart.note": "Note to seller",
+    "cart.notePlaceholder": "e.g., Can we meet at the library?",
+    "cart.send": "Send request",
+    "cart.sending": "Sending...",
+    "cart.error": "Error",
+    "cart.idle": "Idle",
+    "cart.sendFailed": "Failed to send request.",
+    "requests.title": "My Requests",
+    "requests.counts": "{total} total, {accepted} accepted",
+    "requests.loading": "Loading requests...",
+    "requests.empty": "No requests yet",
+    "requests.emptyHelp": "Send a request from your cart to start a trade.",
+    "requests.browse": "Browse items",
+    "requests.qty": "Qty {quantity}",
+    "requests.acceptedContact": "Seller accepted. Contact:",
+    "requests.contactPending": "Contact details appear after the seller accepts your request.",
+    "requests.cancel": "Cancel request",
+    "seller.title": "Seller Dashboard",
+    "seller.counts": "{listings} listings, {pending} pending requests",
+    "seller.myListings": "My Listings",
+    "seller.loadingListings": "Loading listings...",
+    "seller.noListings": "No listings yet.",
+    "seller.buyerRequests": "Buyer Requests",
+    "seller.loadingRequests": "Loading requests...",
+    "seller.noRequests": "No buyer requests yet.",
+    "seller.available": "Available",
+    "seller.pending": "Pending",
+    "seller.sold": "Sold",
+    "seller.buyer": "Buyer {id}",
+    "seller.buyerContact": "Buyer contact:",
+    "seller.emailAfterAccept": "Buyer email appears after you accept the request.",
+    "seller.accept": "Accept",
+    "seller.decline": "Decline",
+  },
+  zh: {
+    "common.language": "語言",
+    "common.english": "EN",
+    "common.zhTw": "繁中",
+    "common.loading": "載入中...",
+    "common.refresh": "重新整理",
+    "common.refreshing": "重新整理中...",
+    "common.clear": "清除",
+    "common.category.general": "一般",
+    "common.category.electronics": "電子產品",
+    "common.category.clothing": "服飾",
+    "common.category.books": "書籍",
+    "common.category.home": "居家",
+    "nav.home": "首頁",
+    "nav.marketplace": "市集",
+    "nav.sell": "刊登",
+    "nav.seller": "賣家",
+    "nav.requests": "需求",
+    "nav.cart": "購物車",
+    "nav.logout": "登出",
+    "auth.login": "登入",
+    "auth.signup": "註冊",
+    "auth.email": "Email",
+    "auth.password": "密碼",
+    "auth.username": "使用者名稱",
+    "auth.loggingIn": "登入中...",
+    "auth.creating": "建立帳號中...",
+    "auth.loginError": "Email 或密碼不正確。",
+    "auth.signupError": "註冊失敗，請確認 email 與密碼。",
+    "auth.confirmEmail": "請查看信箱並完成帳號驗證。",
+    "auth.createdConfirm": "帳號已建立。請完成 email 驗證後再登入。",
+    "home.description":
+      "想出清閒置物品或找划算好物嗎？OSUTrade 讓你可以刊登二手商品、瀏覽校園市集，並快速向賣家送出交易需求。",
+    "home.github": "GitHub",
+    "home.discord": "Discord",
+    "home.support": "支持我們",
+    "home.about": "關於我們",
+    "home.onSale": "熱賣商品",
+    "marketplace.title": "更快找到校園好物。",
+    "marketplace.subtitle":
+      "瀏覽目前可交易的商品，依分類篩選，準備聯絡賣家時可先加入 request cart。",
+    "marketplace.listItem": "刊登商品",
+    "marketplace.loadError": "商品載入失敗：{message}",
+    "marketplace.search": "搜尋",
+    "marketplace.searchPlaceholder": "依商品名稱搜尋",
+    "marketplace.category": "分類",
+    "marketplace.allCategories": "所有分類",
+    "marketplace.sort": "排序",
+    "marketplace.newest": "最新優先",
+    "marketplace.priceAsc": "價格：低到高",
+    "marketplace.priceDesc": "價格：高到低",
+    "marketplace.showing": "顯示 {shown} / {total} 個商品",
+    "marketplace.loadingListings": "商品載入中...",
+    "marketplace.noMatches": "沒有符合的商品",
+    "marketplace.noMatchesHelp": "請清除篩選條件，或成為這個分類第一個刊登商品的人。",
+    "product.addToCart": "加入 request cart",
+    "product.adding": "加入中...",
+    "product.added": "已加入 request cart。",
+    "product.addedDetail": "已加入 request cart，送出前可以再確認內容。",
+    "product.addError": "無法加入商品，請再試一次。",
+    "product.addErrorDetail": "無法加入這個商品，請再試一次。",
+    "product.backMarketplace": "回到市集",
+    "product.loading": "商品載入中...",
+    "product.unavailable": "商品目前無法查看",
+    "product.notFound": "找不到這個商品。",
+    "product.seller": "賣家",
+    "product.contactAfterRequest": "送出交易需求後才會顯示聯絡方式。",
+    "product.stepCart": "先把商品加入 request cart，再附上備註送出需求。",
+    "product.stepSeller": "賣家可以在賣家 dashboard 接受或拒絕需求。",
+    "product.statusUnavailable": "不可交易",
+    "sell.title": "刊登商品",
+    "sell.itemName": "商品名稱",
+    "sell.price": "價格",
+    "sell.productImage": "商品圖片",
+    "sell.imageHelp": "支援 JPG、PNG 或 WebP，最多 5 MB。",
+    "sell.imageUrlFallback": "圖片 URL 備用欄位",
+    "sell.listing": "刊登中...",
+    "sell.submit": "刊登商品",
+    "sell.uploadError": "圖片上傳失敗。",
+    "sell.listError": "商品刊登失敗。",
+    "cart.title": "你的交易需求",
+    "cart.backMarketplace": "回到市集",
+    "cart.loading": "購物車載入中...",
+    "cart.empty": "購物車是空的",
+    "cart.emptyHelp": "到市集加入商品，並向賣家送出交易需求。",
+    "cart.goShopping": "去逛市集",
+    "cart.summary": "需求摘要",
+    "cart.items": "商品數",
+    "cart.subtotal": "小計",
+    "cart.pendingTotal": "待送出 / 全部",
+    "cart.sent": "已送出",
+    "cart.failed": "失敗",
+    "cart.sendAll": "送出全部需求",
+    "cart.remove": "移除",
+    "cart.decrease": "減少數量",
+    "cart.increase": "增加數量",
+    "cart.note": "給賣家的備註",
+    "cart.notePlaceholder": "例如：可以在圖書館碰面嗎？",
+    "cart.send": "送出需求",
+    "cart.sending": "送出中...",
+    "cart.error": "錯誤",
+    "cart.idle": "尚未送出",
+    "cart.sendFailed": "需求送出失敗。",
+    "requests.title": "我的需求",
+    "requests.counts": "共 {total} 筆，{accepted} 筆已接受",
+    "requests.loading": "需求載入中...",
+    "requests.empty": "目前沒有需求",
+    "requests.emptyHelp": "從購物車送出需求後，就會開始交易流程。",
+    "requests.browse": "瀏覽商品",
+    "requests.qty": "數量 {quantity}",
+    "requests.acceptedContact": "賣家已接受。聯絡方式：",
+    "requests.contactPending": "賣家接受需求後，這裡會顯示聯絡方式。",
+    "requests.cancel": "取消需求",
+    "seller.title": "賣家 Dashboard",
+    "seller.counts": "{listings} 個刊登商品，{pending} 筆待處理需求",
+    "seller.myListings": "我的刊登",
+    "seller.loadingListings": "刊登載入中...",
+    "seller.noListings": "尚未刊登商品。",
+    "seller.buyerRequests": "買家需求",
+    "seller.loadingRequests": "需求載入中...",
+    "seller.noRequests": "目前沒有買家需求。",
+    "seller.available": "可交易",
+    "seller.pending": "保留中",
+    "seller.sold": "已售出",
+    "seller.buyer": "買家 {id}",
+    "seller.buyerContact": "買家聯絡方式：",
+    "seller.emailAfterAccept": "接受需求後，這裡會顯示買家 email。",
+    "seller.accept": "接受",
+    "seller.decline": "拒絕",
+  },
+} as const;
+
+type Locale = keyof typeof dictionaries;
+type TranslationKey = keyof typeof dictionaries.en;
+
+type I18nContextValue = {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: TranslationKey, values?: Record<string, string | number>) => string;
+};
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+function translate(
+  locale: Locale,
+  key: TranslationKey,
+  values?: Record<string, string | number>
+) {
+  let text: string = dictionaries[locale][key] ?? dictionaries.en[key] ?? key;
+
+  if (values) {
+    Object.entries(values).forEach(([name, value]) => {
+      text = text.replaceAll(`{${name}}`, String(value));
+    });
+  }
+
+  return text;
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>("en");
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem("osutrade-locale");
+    if (saved === "en" || saved === "zh") {
+      setLocaleState(saved);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = locale === "zh" ? "zh-Hant" : "en";
+    window.localStorage.setItem("osutrade-locale", locale);
+  }, [locale]);
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      locale,
+      setLocale: setLocaleState,
+      t: (key, values) => translate(locale, key, values),
+    }),
+    [locale]
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error("useI18n must be used inside I18nProvider");
+  }
+  return context;
+}
+
+export function LanguageToggle() {
+  const { locale, setLocale, t } = useI18n();
+
+  return (
+    <div
+      className="inline-flex rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
+      aria-label={t("common.language")}
+    >
+      <button
+        type="button"
+        onClick={() => setLocale("en")}
+        className={`rounded px-2 py-1 transition ${
+          locale === "en" ? "bg-[#d73f09] text-white" : "text-gray-700"
+        }`}
+      >
+        {t("common.english")}
+      </button>
+      <button
+        type="button"
+        onClick={() => setLocale("zh")}
+        className={`rounded px-2 py-1 transition ${
+          locale === "zh" ? "bg-[#d73f09] text-white" : "text-gray-700"
+        }`}
+      >
+        {t("common.zhTw")}
+      </button>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,16 @@
-import './globals.css';
+import "./globals.css";
+import { I18nProvider } from "./i18n";
+
 export default function RootLayout({
-    children,
-  }: {
-    children: React.ReactNode
-  }) {
-    return (
-      <html lang="en">
-        <body>{children}</body>
-      </html>
-    )
-  }
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <I18nProvider>{children}</I18nProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -7,6 +7,7 @@ import Header from "../components/Header";
 import ProductCard from "../components/ProductCard";
 import { useProducts } from "../hook/useProducts";
 import type { Product } from "../lib/products";
+import { useI18n } from "../i18n";
 
 const categories = ["all", "electronics", "clothing", "books", "home", "general"];
 
@@ -21,6 +22,7 @@ function sortProductsByPrice(products: Product[], order: string) {
 }
 
 export default function ProductListPage() {
+  const { t } = useI18n();
   const { products, loading, error, refetch } = useProducts();
 
   const [search, setSearch] = useState("");
@@ -59,30 +61,29 @@ export default function ProductListPage() {
           <section className="mb-8 flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
             <div>
               <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-[#d73f09]">
-                Marketplace
+                {t("nav.marketplace")}
               </p>
               <Heading size="8" className="text-3xl font-bold text-gray-900 sm:text-4xl">
-                Find campus deals faster.
+                {t("marketplace.title")}
               </Heading>
               <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-600 sm:text-base">
-                Browse available listings, filter by category, and add items to
-                your request cart when you are ready to contact the seller.
+                {t("marketplace.subtitle")}
               </p>
             </div>
 
             <div className="flex flex-wrap gap-2">
               <Button variant="soft" onClick={() => refetch()} disabled={loading}>
-                {loading ? "Refreshing..." : "Refresh"}
+                {loading ? t("common.refreshing") : t("common.refresh")}
               </Button>
               <Link href="/sell">
-                <Button highContrast>List Item</Button>
+                <Button highContrast>{t("marketplace.listItem")}</Button>
               </Link>
             </div>
           </section>
 
           {error && (
             <div className="mb-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              Failed to load products: {error.message}
+              {t("marketplace.loadError", { message: error.message })}
             </div>
           )}
 
@@ -90,11 +91,11 @@ export default function ProductListPage() {
             <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_220px_auto] md:items-end">
               <label className="block">
                 <span className="mb-1 block text-sm font-medium text-gray-700">
-                  Search
+                  {t("marketplace.search")}
                 </span>
                 <input
                   type="search"
-                  placeholder="Search by item name"
+                  placeholder={t("marketplace.searchPlaceholder")}
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   className="h-10 w-full rounded-md border border-gray-300 bg-white px-3 text-sm outline-none transition focus:border-[#d73f09] focus:ring-2 focus:ring-orange-100"
@@ -103,7 +104,7 @@ export default function ProductListPage() {
 
               <label className="block">
                 <span className="mb-1 block text-sm font-medium text-gray-700">
-                  Category
+                  {t("marketplace.category")}
                 </span>
                 <select
                   value={category}
@@ -112,7 +113,9 @@ export default function ProductListPage() {
                 >
                   {categories.map((item) => (
                     <option key={item} value={item}>
-                      {item === "all" ? "All categories" : item}
+                      {item === "all"
+                        ? t("marketplace.allCategories")
+                        : t(`common.category.${item}` as any)}
                     </option>
                   ))}
                 </select>
@@ -120,16 +123,16 @@ export default function ProductListPage() {
 
               <label className="block">
                 <span className="mb-1 block text-sm font-medium text-gray-700">
-                  Sort
+                  {t("marketplace.sort")}
                 </span>
                 <select
                   value={priceSort}
                   onChange={(e) => setPriceSort(e.target.value)}
                   className="h-10 w-full rounded-md border border-gray-300 bg-white px-3 text-sm outline-none transition focus:border-[#d73f09] focus:ring-2 focus:ring-orange-100"
                 >
-                  <option value="none">Newest first</option>
-                  <option value="asc">Price: low to high</option>
-                  <option value="desc">Price: high to low</option>
+                  <option value="none">{t("marketplace.newest")}</option>
+                  <option value="asc">{t("marketplace.priceAsc")}</option>
+                  <option value="desc">{t("marketplace.priceDesc")}</option>
                 </select>
               </label>
 
@@ -139,19 +142,22 @@ export default function ProductListPage() {
                 disabled={!hasFilters}
                 className="h-10"
               >
-                Clear
+                {t("common.clear")}
               </Button>
             </div>
 
             <div className="mt-3 text-sm text-gray-600">
-              Showing {filteredProducts.length} of {products.length} listings
+              {t("marketplace.showing", {
+                shown: filteredProducts.length,
+                total: products.length,
+              })}
             </div>
           </section>
 
           <section className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {loading ? (
               <div className="col-span-full rounded-lg border border-dashed border-orange-200 bg-white/60 px-6 py-12 text-center text-gray-600">
-                Loading listings...
+                {t("marketplace.loadingListings")}
               </div>
             ) : filteredProducts.length > 0 ? (
               filteredProducts.map((product) => (
@@ -169,10 +175,10 @@ export default function ProductListPage() {
             ) : (
               <div className="col-span-full rounded-lg border border-dashed border-orange-200 bg-white/60 px-6 py-12 text-center">
                 <Heading size="4" className="text-gray-900">
-                  No matching listings
+                  {t("marketplace.noMatches")}
                 </Heading>
                 <p className="mt-2 text-sm text-gray-600">
-                  Try clearing filters or list the first item in this category.
+                  {t("marketplace.noMatchesHelp")}
                 </p>
               </div>
             )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
-// app/page.tsx
+"use client";
+
 import "@radix-ui/themes/styles.css";
 import { Theme, Heading, Text, Button, Card } from "@radix-ui/themes";
 import {
@@ -6,15 +7,17 @@ import {
   ChatBubbleIcon,
   HeartIcon,
 } from "@radix-ui/react-icons";
-import dynamic from "next/dynamic";
 import TimezoneCards from "./components/TimezoneCards";
 import OnlineUsersCard from "./components/OnlineUsersCard";
 import LoginModal from "./components/LoginModal";
 import SignUpModal from "./components/SignUpModal";
 import ProductListCard from "./components/ProductListCard";
 import FundingProgressCard from "./components/FundingProgressCard";
+import { LanguageToggle, useI18n } from "./i18n";
 
 export default function HomePage() {
+  const { t } = useI18n();
+
   return (
     <Theme
       appearance="light"
@@ -23,51 +26,49 @@ export default function HomePage() {
       radius="large"
     >
       <div className="min-h-screen bg-gradient-to-br from-white via-[#fff1f1] to-[#ffe6e6] p-8">
-        <div className="grid grid-cols-1 xl:grid-cols-3 gap-8 max-w-screen-xl mx-auto align-middle">
-          {/* Left Column */}
+        <div className="mx-auto mb-6 flex max-w-screen-xl justify-end">
+          <LanguageToggle />
+        </div>
+
+        <div className="mx-auto grid max-w-screen-xl grid-cols-1 gap-8 align-middle xl:grid-cols-3">
           <div className="col-span-1 flex flex-col gap-6">
             <Heading size="9" weight="bold" className="text-[#d73f09]">
               OSUTrade
             </Heading>
             <Text size="3" className="text-gray-700">
-              Looking to declutter or find great deals? Our secondhand trading
-              platform is made just for OSU students! Easily upload photos of
-              your items, browse listings from fellow students, and meet up
-              using built-in location maps. Start trading smart—join the
-              community today!
+              {t("home.description")}
             </Text>
             <div className="flex gap-4">
               <SignUpModal />
               <LoginModal />
             </div>
-            <div className="flex gap-4">
-              <Button size="3" className="bg-[#24292f] text-white rounded-md">
-                <GitHubLogoIcon className="mr-2" /> GitHub
+            <div className="flex flex-wrap gap-4">
+              <Button size="3" className="rounded-md bg-[#24292f] text-white">
+                <GitHubLogoIcon className="mr-2" /> {t("home.github")}
               </Button>
-              <Button size="3" className="bg-[#5865F2] text-white rounded-md">
-                <ChatBubbleIcon className="mr-2" /> Discord
+              <Button size="3" className="rounded-md bg-[#5865F2] text-white">
+                <ChatBubbleIcon className="mr-2" /> {t("home.discord")}
               </Button>
               <Button
                 size="3"
                 variant="outline"
                 className="rounded-md border-[#d73f09] text-[#d73f09]"
               >
-                <HeartIcon className="mr-2" /> Support Us
+                <HeartIcon className="mr-2" /> {t("home.support")}
               </Button>
             </div>
           </div>
 
-          {/* Center Column */}
           <div className="col-span-1 flex flex-col gap-6">
             <ProductListCard />
             <FundingProgressCard />
-            <Card className="bg-white/70 backdrop-blur-md p-4 border border-orange-300 shadow hover:scale-[1.02] transition-transform">
+            <Card className="border border-orange-300 bg-white/70 p-4 shadow backdrop-blur-md transition-transform hover:scale-[1.02]">
               <Heading size="5" mb="2">
-                About Us
+                {t("home.about")}
               </Heading>
               <div className="aspect-w-16 aspect-h-9">
                 <iframe
-                  className="rounded-lg w-full h-64"
+                  className="h-64 w-full rounded-lg"
                   src="https://www.youtube.com/embed/dQw4w9WgXcQ"
                   title="YouTube video player"
                   frameBorder="0"
@@ -78,7 +79,6 @@ export default function HomePage() {
             </Card>
           </div>
 
-          {/* Right Column */}
           <div className="col-span-1 flex flex-col gap-6">
             <OnlineUsersCard />
             <TimezoneCards />

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { ArrowLeft, CheckCircle2, ShoppingCart, Store } from "lucide-react";
 import { fetchProduct, type Product } from "@/app/lib/products";
+import { useI18n } from "@/app/i18n";
 
 const fallbackImage = "https://placehold.co/1000x750/f9fafb/d73f09?text=OSUTrade";
 
@@ -15,6 +16,7 @@ type Feedback = {
 };
 
 export default function ProductDetailPage() {
+  const { t } = useI18n();
   const { id } = useParams<{ id: string }>();
   const [product, setProduct] = useState<Product | null>(null);
   const [selectedImage, setSelectedImage] = useState<string>(fallbackImage);
@@ -75,12 +77,12 @@ export default function ProductDetailPage() {
 
       setFeedback({
         tone: "success",
-        message: "Added to request cart. You can review it before sending.",
+        message: t("product.addedDetail"),
       });
     } catch {
       setFeedback({
         tone: "error",
-        message: "Could not add this item. Please try again.",
+        message: t("product.addErrorDetail"),
       });
     } finally {
       setAdding(false);
@@ -91,7 +93,7 @@ export default function ProductDetailPage() {
     return (
       <main className="min-h-screen bg-[#fff8f4] px-4 py-16">
         <div className="mx-auto max-w-5xl rounded-lg border border-orange-100 bg-white p-8 text-center text-gray-600 shadow-sm">
-          Loading item...
+          {t("product.loading")}
         </div>
       </main>
     );
@@ -101,13 +103,13 @@ export default function ProductDetailPage() {
     return (
       <main className="min-h-screen bg-[#fff8f4] px-4 py-16">
         <div className="mx-auto max-w-3xl rounded-lg border border-red-100 bg-white p-8 text-center shadow-sm">
-          <h1 className="text-2xl font-bold text-gray-900">Product unavailable</h1>
-          <p className="mt-2 text-gray-600">{error || "This item was not found."}</p>
+          <h1 className="text-2xl font-bold text-gray-900">{t("product.unavailable")}</h1>
+          <p className="mt-2 text-gray-600">{error || t("product.notFound")}</p>
           <Link
             href="/overview"
             className="mt-6 inline-flex items-center gap-2 rounded-md bg-[#d73f09] px-4 py-2 text-sm font-semibold text-white"
           >
-            <ArrowLeft size={16} /> Back to marketplace
+            <ArrowLeft size={16} /> {t("product.backMarketplace")}
           </Link>
         </div>
       </main>
@@ -124,7 +126,7 @@ export default function ProductDetailPage() {
           href="/overview"
           className="mb-6 inline-flex items-center gap-2 text-sm font-medium text-[#d73f09] hover:text-[#b43305]"
         >
-          <ArrowLeft size={16} /> Back to marketplace
+          <ArrowLeft size={16} /> {t("product.backMarketplace")}
         </Link>
 
         <section className="grid gap-8 rounded-xl border border-orange-100 bg-white p-4 shadow-sm md:grid-cols-[minmax(0,1.1fr)_minmax(340px,0.9fr)] md:p-6">
@@ -187,9 +189,9 @@ export default function ProductDetailPage() {
               <div className="flex items-center gap-3 text-gray-800">
                 <Store size={20} className="text-[#d73f09]" />
                 <div>
-                  <p className="font-semibold">Seller</p>
+                  <p className="font-semibold">{t("product.seller")}</p>
                   <p className="text-sm text-gray-600">
-                    Contact is handled after you send a request.
+                    {t("product.contactAfterRequest")}
                   </p>
                 </div>
               </div>
@@ -198,11 +200,11 @@ export default function ProductDetailPage() {
             <div className="mt-6 space-y-3 text-sm text-gray-600">
               <div className="flex gap-2">
                 <CheckCircle2 size={18} className="mt-0.5 shrink-0 text-green-600" />
-                <p>Add the item to your request cart, then send one request with notes.</p>
+                <p>{t("product.stepCart")}</p>
               </div>
               <div className="flex gap-2">
                 <CheckCircle2 size={18} className="mt-0.5 shrink-0 text-green-600" />
-                <p>The seller can accept or decline from their seller dashboard.</p>
+                <p>{t("product.stepSeller")}</p>
               </div>
             </div>
 
@@ -213,7 +215,11 @@ export default function ProductDetailPage() {
                 className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#d73f09] px-5 py-3 font-semibold text-white transition hover:bg-[#b43305] disabled:cursor-not-allowed disabled:bg-gray-300"
               >
                 <ShoppingCart size={20} />
-                {adding ? "Adding..." : isAvailable ? "Add to request cart" : "Unavailable"}
+                {adding
+                  ? t("product.adding")
+                  : isAvailable
+                    ? t("product.addToCart")
+                    : t("product.statusUnavailable")}
               </button>
 
               {feedback && (

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Badge, Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
 import { ArrowLeftIcon } from "@radix-ui/react-icons";
 import Header from "../components/Header";
+import { useI18n } from "../i18n";
 
 type RequestStatus = "sent" | "accepted" | "declined" | "cancelled";
 
@@ -28,6 +29,7 @@ const currency = (n: number) =>
   n.toLocaleString("en-US", { style: "currency", currency: "USD" });
 
 export default function RequestsPage() {
+  const { t } = useI18n();
   const [requests, setRequests] = useState<BuyerRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -77,16 +79,19 @@ export default function RequestsPage() {
           <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
             <div>
               <Heading size="8" className="text-[#333]">
-                My Requests
+                {t("requests.title")}
               </Heading>
               <Text color="gray">
-                {requests.length} total, {acceptedCount} accepted
+                {t("requests.counts", {
+                  total: requests.length,
+                  accepted: acceptedCount,
+                })}
               </Text>
             </div>
 
             <Link href="/overview">
               <Button variant="soft">
-                <ArrowLeftIcon /> Marketplace
+                <ArrowLeftIcon /> {t("nav.marketplace")}
               </Button>
             </Link>
           </div>
@@ -99,18 +104,18 @@ export default function RequestsPage() {
 
           <div className="space-y-4">
             {loading ? (
-              <Card className="p-5">Loading requests...</Card>
+              <Card className="p-5">{t("requests.loading")}</Card>
             ) : requests.length === 0 ? (
               <Card className="p-8 text-center">
                 <Heading size="5" className="mb-2">
-                  No requests yet
+                  {t("requests.empty")}
                 </Heading>
                 <Text color="gray">
-                  Send a request from your cart to start a trade.
+                  {t("requests.emptyHelp")}
                 </Text>
                 <div className="mt-5">
                   <Link href="/overview">
-                    <Button highContrast>Browse items</Button>
+                    <Button highContrast>{t("requests.browse")}</Button>
                   </Link>
                 </div>
               </Card>
@@ -120,6 +125,7 @@ export default function RequestsPage() {
                   key={request.id}
                   request={request}
                   onCancel={() => cancelRequest(request.id)}
+                  t={t}
                 />
               ))
             )}
@@ -133,9 +139,11 @@ export default function RequestsPage() {
 function RequestCard({
   request,
   onCancel,
+  t,
 }: {
   request: BuyerRequest;
   onCancel: () => void;
+  t: ReturnType<typeof useI18n>["t"];
 }) {
   return (
     <Card className="border border-orange-200 bg-white/70 p-4 shadow">
@@ -152,7 +160,7 @@ function RequestCard({
                 {request.product?.name || `Item ${request.itemId}`}
               </Text>
               <Text color="gray" size="2">
-                Qty {request.quantity}
+                {t("requests.qty", { quantity: request.quantity })}
                 {request.product ? ` - ${currency(request.product.price)}` : ""}
               </Text>
             </div>
@@ -167,20 +175,20 @@ function RequestCard({
 
           {request.status === "accepted" && request.sellerEmail ? (
             <div className="mt-3 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">
-              Seller accepted. Contact:{" "}
+              {t("requests.acceptedContact")}{" "}
               <a className="font-medium underline" href={`mailto:${request.sellerEmail}`}>
                 {request.sellerEmail}
               </a>
             </div>
           ) : (
             <Text className="mt-3 block" color="gray" size="2">
-              Contact details appear after the seller accepts your request.
+              {t("requests.contactPending")}
             </Text>
           )}
 
           {request.status === "sent" && (
             <Button className="mt-4" color="red" variant="soft" onClick={onCancel}>
-              Cancel request
+              {t("requests.cancel")}
             </Button>
           )}
         </div>

--- a/app/sell/page.tsx
+++ b/app/sell/page.tsx
@@ -5,10 +5,12 @@ import { useRouter } from "next/navigation";
 import { Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
 import Header from "../components/Header";
 import type { Product } from "../lib/products";
+import { useI18n } from "../i18n";
 
 const categories = ["general", "electronics", "clothing", "books", "home"];
 
 export default function SellPage() {
+  const { t } = useI18n();
   const router = useRouter();
   const [name, setName] = useState("");
   const [price, setPrice] = useState("");
@@ -37,7 +39,7 @@ export default function SellPage() {
       if (!uploadRes.ok) {
         const payload = await uploadRes.json().catch(() => null);
         setLoading(false);
-        setError(payload?.message || "Failed to upload image.");
+        setError(payload?.message || t("sell.uploadError"));
         return;
       }
 
@@ -60,7 +62,7 @@ export default function SellPage() {
 
     if (!res.ok) {
       const payload = await res.json().catch(() => null);
-      setError(payload?.message || "Failed to list item.");
+      setError(payload?.message || t("sell.listError"));
       return;
     }
 
@@ -74,14 +76,14 @@ export default function SellPage() {
         <Header />
         <section className="mx-auto max-w-2xl">
           <Heading size="8" className="mb-8 text-center text-[#333]">
-            List an Item
+            {t("sell.title")}
           </Heading>
 
           <Card className="border border-orange-200 bg-white/75 p-6 shadow">
             <form className="space-y-5" onSubmit={onSubmit}>
               <label className="block">
                 <Text as="span" size="2" weight="medium">
-                  Item name
+                  {t("sell.itemName")}
                 </Text>
                 <input
                   className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
@@ -93,7 +95,7 @@ export default function SellPage() {
 
               <label className="block">
                 <Text as="span" size="2" weight="medium">
-                  Price
+                  {t("sell.price")}
                 </Text>
                 <input
                   className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
@@ -108,7 +110,7 @@ export default function SellPage() {
 
               <label className="block">
                 <Text as="span" size="2" weight="medium">
-                  Category
+                  {t("marketplace.category")}
                 </Text>
                 <select
                   className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
@@ -117,7 +119,7 @@ export default function SellPage() {
                 >
                   {categories.map((item) => (
                     <option key={item} value={item}>
-                      {item}
+                      {t(`common.category.${item}` as any)}
                     </option>
                   ))}
                 </select>
@@ -125,7 +127,7 @@ export default function SellPage() {
 
               <label className="block">
                 <Text as="span" size="2" weight="medium">
-                  Product image
+                  {t("sell.productImage")}
                 </Text>
                 <input
                   className="mt-2 w-full rounded-md border border-gray-300 bg-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
@@ -134,13 +136,13 @@ export default function SellPage() {
                   onChange={(event) => setImageFile(event.target.files?.[0] ?? null)}
                 />
                 <Text as="p" size="1" color="gray" className="mt-1">
-                  JPG, PNG, or WebP up to 5 MB.
+                  {t("sell.imageHelp")}
                 </Text>
               </label>
 
               <label className="block">
                 <Text as="span" size="2" weight="medium">
-                  Image URL fallback
+                  {t("sell.imageUrlFallback")}
                 </Text>
                 <input
                   className="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-orange-400"
@@ -159,7 +161,7 @@ export default function SellPage() {
               )}
 
               <Button highContrast type="submit" disabled={loading}>
-                {loading ? "Listing..." : "List item"}
+                {loading ? t("sell.listing") : t("sell.submit")}
               </Button>
             </form>
           </Card>

--- a/app/seller/page.tsx
+++ b/app/seller/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Badge, Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
 import { ArrowLeftIcon, CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
 import Header from "../components/Header";
+import { useI18n } from "../i18n";
 
 type ProductStatus = "available" | "pending" | "sold" | "removed";
 type RequestStatus = "sent" | "accepted" | "declined" | "cancelled";
@@ -39,6 +40,7 @@ const currency = (n: number) =>
   n.toLocaleString("en-US", { style: "currency", currency: "USD" });
 
 export default function SellerPage() {
+  const { t } = useI18n();
   const [products, setProducts] = useState<SellerProduct[]>([]);
   const [requests, setRequests] = useState<SellerRequest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -118,21 +120,24 @@ export default function SellerPage() {
           <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
             <div>
               <Heading size="8" className="text-[#333]">
-                Seller Dashboard
+                {t("seller.title")}
               </Heading>
               <Text color="gray">
-                {products.length} listings, {pendingRequests} pending requests
+                {t("seller.counts", {
+                  listings: products.length,
+                  pending: pendingRequests,
+                })}
               </Text>
             </div>
 
             <div className="flex gap-3">
               <Link href="/overview">
                 <Button variant="soft">
-                  <ArrowLeftIcon /> Marketplace
+                  <ArrowLeftIcon /> {t("nav.marketplace")}
                 </Button>
               </Link>
               <Link href="/sell">
-                <Button highContrast>List Item</Button>
+                <Button highContrast>{t("marketplace.listItem")}</Button>
               </Link>
             </div>
           </div>
@@ -146,14 +151,14 @@ export default function SellerPage() {
           <div className="grid gap-6 lg:grid-cols-[1fr,1.1fr]">
             <section>
               <Heading size="5" className="mb-4">
-                My Listings
+                {t("seller.myListings")}
               </Heading>
               <div className="space-y-4">
                 {loading ? (
-                  <Card className="p-5">Loading listings...</Card>
+                  <Card className="p-5">{t("seller.loadingListings")}</Card>
                 ) : products.length === 0 ? (
                   <Card className="p-5">
-                    <Text color="gray">No listings yet.</Text>
+                    <Text color="gray">{t("seller.noListings")}</Text>
                   </Card>
                 ) : (
                   products.map((product) => (
@@ -161,6 +166,7 @@ export default function SellerPage() {
                       key={product.id}
                       product={product}
                       onStatus={(status) => updateProduct(product.id, status)}
+                      t={t}
                     />
                   ))
                 )}
@@ -169,14 +175,14 @@ export default function SellerPage() {
 
             <section>
               <Heading size="5" className="mb-4">
-                Buyer Requests
+                {t("seller.buyerRequests")}
               </Heading>
               <div className="space-y-4">
                 {loading ? (
-                  <Card className="p-5">Loading requests...</Card>
+                  <Card className="p-5">{t("seller.loadingRequests")}</Card>
                 ) : requests.length === 0 ? (
                   <Card className="p-5">
-                    <Text color="gray">No buyer requests yet.</Text>
+                    <Text color="gray">{t("seller.noRequests")}</Text>
                   </Card>
                 ) : (
                   requests.map((request) => (
@@ -184,6 +190,7 @@ export default function SellerPage() {
                       key={request.id}
                       request={request}
                       onUpdate={(status) => updateRequest(request.id, status)}
+                      t={t}
                     />
                   ))
                 )}
@@ -199,9 +206,11 @@ export default function SellerPage() {
 function ProductRow({
   product,
   onStatus,
+  t,
 }: {
   product: SellerProduct;
   onStatus: (status: ProductStatus) => void;
+  t: ReturnType<typeof useI18n>["t"];
 }) {
   return (
     <Card className="border border-orange-200 bg-white/70 p-4 shadow">
@@ -216,7 +225,10 @@ function ProductRow({
             <div>
               <Text className="block font-medium">{product.name}</Text>
               <Text color="gray" size="2">
-                {product.category || "general"} - {currency(product.price)}
+              {product.category
+                ? t(`common.category.${product.category}` as any)
+                : t("common.category.general")}{" "}
+              - {currency(product.price)}
               </Text>
             </div>
             <StatusBadge status={product.status} />
@@ -229,7 +241,7 @@ function ProductRow({
               onClick={() => onStatus("available")}
               disabled={product.status === "available"}
             >
-              Available
+              {t("seller.available")}
             </Button>
             <Button
               size="2"
@@ -237,7 +249,7 @@ function ProductRow({
               onClick={() => onStatus("pending")}
               disabled={product.status === "pending"}
             >
-              Pending
+              {t("seller.pending")}
             </Button>
             <Button
               size="2"
@@ -245,7 +257,7 @@ function ProductRow({
               onClick={() => onStatus("sold")}
               disabled={product.status === "sold"}
             >
-              Sold
+              {t("seller.sold")}
             </Button>
           </div>
         </div>
@@ -257,9 +269,11 @@ function ProductRow({
 function RequestRow({
   request,
   onUpdate,
+  t,
 }: {
   request: SellerRequest;
   onUpdate: (status: RequestStatus) => void;
+  t: ReturnType<typeof useI18n>["t"];
 }) {
   return (
     <Card className="border border-orange-200 bg-white/70 p-4 shadow">
@@ -269,7 +283,8 @@ function RequestRow({
             {request.product?.name || `Item ${request.itemId}`}
           </Text>
           <Text color="gray" size="2">
-            Qty {request.quantity} - Buyer {request.buyerId.slice(0, 8)}
+            {t("requests.qty", { quantity: request.quantity })} -{" "}
+            {t("seller.buyer", { id: request.buyerId.slice(0, 8) })}
           </Text>
         </div>
         <StatusBadge status={request.status} />
@@ -283,14 +298,14 @@ function RequestRow({
 
       {request.status === "accepted" && request.buyerEmail ? (
         <div className="mt-3 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">
-          Buyer contact:{" "}
+          {t("seller.buyerContact")}{" "}
           <a className="font-medium underline" href={`mailto:${request.buyerEmail}`}>
             {request.buyerEmail}
           </a>
         </div>
       ) : (
         <Text className="mt-3 block" color="gray" size="2">
-          Buyer email appears after you accept the request.
+          {t("seller.emailAfterAccept")}
         </Text>
       )}
 
@@ -301,7 +316,7 @@ function RequestRow({
           onClick={() => onUpdate("accepted")}
           disabled={request.status === "accepted"}
         >
-          <CheckIcon /> Accept
+          <CheckIcon /> {t("seller.accept")}
         </Button>
         <Button
           size="2"
@@ -310,7 +325,7 @@ function RequestRow({
           onClick={() => onUpdate("declined")}
           disabled={request.status === "declined"}
         >
-          <Cross2Icon /> Decline
+          <Cross2Icon /> {t("seller.decline")}
         </Button>
       </div>
     </Card>


### PR DESCRIPTION
## Summary
- add a lightweight client-side i18n provider with English and Traditional Chinese dictionaries
- add a persistent language toggle that stores the selected locale in localStorage
- translate the main MVP UI flows: home, auth modals, marketplace, product cards/details, sell, cart, requests, and seller dashboard

## Validation
- `npm.cmd run build`
- `npm.cmd test -- --run`
- local production smoke: `/` returned 200, `/api/products?limit=1` returned 200, `/overview` redirected as expected for anonymous users