### PR TITLE
Prevent header auth controls from shrinking

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -35,7 +35,7 @@ export default function Header() {
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
     >
-      <div className="mx-auto flex max-w-7xl flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div className="mx-auto flex w-full max-w-none flex-col gap-3 px-2 lg:flex-row lg:items-center lg:justify-between">
         <Link
           href="/"
           className="shrink-0 text-xl font-bold text-[#d73f09] sm:text-2xl"
@@ -43,7 +43,7 @@ export default function Header() {
           OSUTrade
         </Link>
 
-        <nav className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 lg:justify-end">
+        <nav className="flex min-w-0 flex-1 flex-wrap items-center gap-2 lg:flex-nowrap lg:justify-end">
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 lg:justify-end">
             <Link href="/" className={navLinkClass}>
               {t("nav.home")}
@@ -65,7 +65,7 @@ export default function Header() {
             </Link>
           </div>
 
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex min-w-max shrink-0 items-center justify-end gap-2">
             <LanguageToggle />
 
             {!user ? (

--- a/app/components/LoginModal.tsx
+++ b/app/components/LoginModal.tsx
@@ -43,7 +43,7 @@ export default function LoginModal() {
       <Button
         size="3"
         variant="outline"
-        className="border-[#d73f09] text-[#d73f09]"
+        className="min-w-[76px] shrink-0 whitespace-nowrap border-[#d73f09] px-3 text-[#d73f09]"
         onClick={() => setIsOpen(true)}
       >
         {t("auth.login")}

--- a/app/components/SignUpModal.tsx
+++ b/app/components/SignUpModal.tsx
@@ -69,7 +69,7 @@ export default function SignUpModal() {
       <Button
         size="3"
         highContrast
-        className="bg-[#1a1a1a] text-white hover:bg-[#333]"
+        className="min-w-[92px] shrink-0 whitespace-nowrap bg-[#1a1a1a] px-3 text-white hover:bg-[#333]"
         onClick={() => setIsOpen(true)}
       >
         {t("auth.signup")}

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -359,7 +359,7 @@ export function LanguageToggle() {
 
   return (
     <div
-      className="inline-flex rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
+      className="inline-flex min-w-[96px] shrink-0 rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
       aria-label={t("common.language")}
     >
       <button


### PR DESCRIPTION
## Summary
- keep the header auth controls at their natural width
- add minimum widths and no-wrap behavior to login/sign-up buttons
- give the language toggle a fixed minimum width
- allow the header inner container to use full viewport width instead of squeezing inside the previous max width

## Validation
- `npm.cmd run build`
- `npm.cmd test -- --run`