### PR TITLE
Lock header control element widths

### DIFF
--- a/app/components/LoginModal.tsx
+++ b/app/components/LoginModal.tsx
@@ -44,6 +44,12 @@ export default function LoginModal() {
         size="3"
         variant="outline"
         className="min-w-[76px] shrink-0 whitespace-nowrap border-[#d73f09] px-3 text-[#d73f09]"
+        style={{
+          flexShrink: 0,
+          minWidth: "76px",
+          width: "auto",
+          whiteSpace: "nowrap",
+        }}
         onClick={() => setIsOpen(true)}
       >
         {t("auth.login")}

--- a/app/components/SignUpModal.tsx
+++ b/app/components/SignUpModal.tsx
@@ -70,6 +70,12 @@ export default function SignUpModal() {
         size="3"
         highContrast
         className="min-w-[92px] shrink-0 whitespace-nowrap bg-[#1a1a1a] px-3 text-white hover:bg-[#333]"
+        style={{
+          flexShrink: 0,
+          minWidth: "92px",
+          width: "auto",
+          whiteSpace: "nowrap",
+        }}
         onClick={() => setIsOpen(true)}
       >
         {t("auth.signup")}

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -360,6 +360,12 @@ export function LanguageToggle() {
   return (
     <div
       className="inline-flex min-w-[96px] shrink-0 rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
+      style={{
+        flexShrink: 0,
+        minWidth: "96px",
+        width: "96px",
+        boxSizing: "border-box",
+      }}
       aria-label={t("common.language")}
     >
       <button


### PR DESCRIPTION
## Summary
- add element-level width and flex-shrink styles to the header login/sign-up buttons
- give the language toggle an explicit fixed width and box sizing
- avoid relying only on utility classes where Radix component styles may win the cascade

## Validation
- `npm.cmd run build`
- `npm.cmd test -- --run`