### PR TITLE
Add multilingual README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OSUTrade
 
+**Language:** English | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md)
+
 > A campus-first secondhand marketplace for listing, browsing, and requesting used items with a safer buyer-seller workflow.
 
 OSUTrade is a full-stack marketplace built for campus communities. It helps students and local users list unused items, discover affordable secondhand goods, and contact sellers only after a trade request is accepted.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,182 @@
+# OSUTrade
+
+**语言：** [English](README.md) | [繁體中文](README.zh-TW.md) | 简体中文
+
+> 一个以校园社区为核心的二手物品交易平台，支持商品发布、浏览、购买请求，以及更安全的买卖双方联系流程。
+
+OSUTrade 是为校园与本地社区打造的 full-stack marketplace。它帮助用户发布闲置物品、寻找价格友好的二手商品，并且只在卖家接受交易请求后才公开联系方式。
+
+产品重点放在三件事：清晰的商品信息、更安全的联系流程，以及多语言可用性。
+
+[GitHub Repository](https://github.com/barrychung1112/OSUTrade) | [Discord Community](https://discord.gg/BqqAmmjJR) | [Buy Me a Coffee](https://buymeacoffee.com/osutrade)
+
+## 项目介绍
+
+OSUTrade 让校园二手交易更容易：
+
+- 卖家可以创建商品发布，包含照片、分类、价格、数量与商品状态。
+- 买家可以浏览市场、筛选商品，并把商品加入购买请求购物车。
+- 买家提交包含数量与备注的交易请求，不需要一开始就公开联系方式。
+- 卖家可以在卖家 Dashboard 接受或拒绝请求。
+- 联系 email 只会在请求被接受后才显示。
+- 界面支持英文、繁体中文与简体中文。
+- 新商品可以保存 AI 生成的多语言商品名称，让市场跟随用户语言显示。
+- 卖家可以使用 AI 定价建议，估算合理的二手售价。
+
+## 为什么需要它
+
+校园二手交易常散落在聊天群、社交帖文和电子表格里，导致搜索、比较、跟踪请求与安全交换联系方式都不方便。
+
+OSUTrade 将这些流程集中在同一个地方：
+
+- **对买家：** 浏览可购买商品、指定需要的数量，并跟踪交易请求状态。
+- **对卖家：** 管理发布商品、掌握库存，并在同一个 Dashboard 回复买家。
+- **对社区：** 让物品重复使用更简单，减少浪费，也让实惠商品在本地社区中流通。
+
+## 核心功能
+
+| 区块 | 功能 |
+| --- | --- |
+| 市场 | 浏览商品、查看详情、按本地化商品名称搜索，并按分类筛选。 |
+| 商品发布 | 创建包含价格、分类、图片、数量与状态的商品。 |
+| 购买请求购物车 | 在联系卖家前，先将商品加入类似购物车的请求流程。 |
+| 数量限制 | 买家不能请求超过卖家当前库存的数量。 |
+| 买家请求 | 跟踪已提交、已接受、已拒绝与已取消的请求。 |
+| 卖家 Dashboard | 管理商品、更新状态，并处理买家请求。 |
+| 安全联系流程 | 只有在卖家接受请求后，买卖双方 email 才会显示。 |
+| 多语言 | 支持英文、繁体中文与简体中文切换。 |
+| AI 翻译 | 新商品名称可翻译成支持语言并存入 Supabase。 |
+| AI 定价建议 | 根据本地市场信号与新品价格语境，建议二手售价。 |
+| API 文档 | 可通过 Swagger UI 探索 API。 |
+
+## 产品流程
+
+### 买家
+
+1. 浏览市场。
+2. 打开商品详情页。
+3. 将商品与数量加入购买请求购物车。
+4. 加入给卖家的备注。
+5. 提交请求。
+6. 从 **Requests** 跟踪请求状态。
+7. 如果请求被接受，使用显示出的卖家 email 安排取货或交易。
+
+### 卖家
+
+1. 从 **Sell** 创建商品发布。
+2. 视需要使用 AI 定价建议。
+3. 通过多语言市场体验确认商品名称翻译。
+4. 从 **Seller** 管理库存与商品状态。
+5. 接受或拒绝买家请求。
+6. 只在接受请求后分享联系方式。
+
+## 技术架构
+
+- **Framework:** Next.js 15, React 19, TypeScript
+- **UI:** Radix UI, Tailwind CSS, lucide-react
+- **Auth & Database:** Supabase, NextAuth
+- **Testing:** Vitest, Testing Library
+- **AI:** OpenAI API 用于定价建议与商品名称翻译
+- **Deployment:** Vercel
+
+## 使用说明
+
+### 1. 安装依赖
+
+```bash
+npm install
+```
+
+### 2. 创建环境变量
+
+从 `.env.example` 创建 `.env.local`：
+
+```bash
+cp .env.example .env.local
+```
+
+然后填入必要值：
+
+```env
+NEXT_PUBLIC_SUPABASE_URL="https://your-project-ref.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-publishable-or-anon-key"
+SUPABASE_SERVICE_ROLE_KEY="your-server-only-service-role-key"
+AUTH_SECRET="your-auth-secret"
+AUTH_BASE_URL="http://localhost:3000"
+ENABLE_DEMO_PRODUCTS="false"
+OPENAI_API_KEY=""
+OPENAI_PRICING_MODEL="gpt-4.1-mini"
+OPENAI_TRANSLATION_MODEL="gpt-4.1-mini"
+```
+
+注意事项：
+
+- `OPENAI_API_KEY` 对本地 UI 测试是选填，但 AI 定价与翻译功能需要它。
+- 请使用新的私密密钥，且不要把任何 secret commit 到 repository。
+- `SUPABASE_SERVICE_ROLE_KEY` 只能在 server-side 使用。
+
+### 3. 建立 Supabase schema
+
+执行以下 SQL 文件：
+
+```text
+supabase/mvp-schema.sql
+```
+
+至少商品翻译功能需要：
+
+```sql
+alter table public.products
+  add column if not exists name_en text,
+  add column if not exists name_zh_tw text,
+  add column if not exists name_zh_cn text;
+```
+
+### 4. 启动本地开发服务器
+
+```bash
+npm run dev
+```
+
+打开：
+
+```text
+http://localhost:3000
+```
+
+## 常用命令
+
+```bash
+npm run dev
+npm run build
+npm run start
+npm test -- --run
+```
+
+## 主要路由
+
+| 路由 | 用途 |
+| --- | --- |
+| `/` | 产品首页与入口。 |
+| `/overview` | 市场浏览体验。 |
+| `/product/[id]` | 商品详情与加入购买请求流程。 |
+| `/sell` | 卖家发布表单与 AI 定价建议。 |
+| `/cart` | 购买请求购物车与买家请求提交。 |
+| `/requests` | 买家请求跟踪。 |
+| `/seller` | 卖家 Dashboard，管理商品与收到的请求。 |
+| `/docs/swagger` | API 文档。 |
+
+## 作者介绍
+
+**Barry Chung**
+
+Barry Chung 是 OSUTrade 的创作者，将这个项目打造为一个实用的校园二手交易 full-stack marketplace。项目结合产品思维、marketplace UX、Supabase 工作流程、多语言支持，以及 AI 辅助卖家工具。
+
+- GitHub: [barrychung1112](https://github.com/barrychung1112)
+- Project: [OSUTrade](https://github.com/barrychung1112/OSUTrade)
+- Discord: [OSUTrade Community](https://discord.gg/BqqAmmjJR)
+- Support: [Buy Me a Coffee](https://buymeacoffee.com/osutrade)
+
+## 愿景
+
+OSUTrade 目标成为一个轻量、可信任的本地校园 marketplace：足够简单，让用户能快速发布；足够有结构，能支持认真的交易流程；也足够贴心，在双方准备好联系之前保护用户信息。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,182 @@
+# OSUTrade
+
+**語言：** [English](README.md) | 繁體中文 | [简体中文](README.zh-CN.md)
+
+> 一個以校園社群為核心的二手物品交易平台，支援商品刊登、瀏覽、購買請求，以及更安全的買賣雙方聯絡流程。
+
+OSUTrade 是為校園與在地社群打造的 full-stack marketplace。它協助使用者刊登閒置物品、尋找價格友善的二手商品，並且只在賣家接受交易請求後才揭露聯絡資訊。
+
+產品重點放在三件事：清楚的商品資訊、更安全的聯絡流程，以及多語系可用性。
+
+[GitHub Repository](https://github.com/barrychung1112/OSUTrade) | [Discord Community](https://discord.gg/BqqAmmjJR) | [Buy Me a Coffee](https://buymeacoffee.com/osutrade)
+
+## 專案介紹
+
+OSUTrade 讓校園二手交易更容易：
+
+- 賣家可以建立商品刊登，包含照片、分類、價格、數量與商品狀態。
+- 買家可以瀏覽市集、篩選商品，並把商品加入購買請求購物車。
+- 買家送出包含數量與備註的交易請求，不需要一開始就公開聯絡方式。
+- 賣家可以在賣家 Dashboard 接受或拒絕請求。
+- 聯絡 email 只會在請求被接受後才顯示。
+- 介面支援英文、繁體中文與簡體中文。
+- 新商品可以儲存 AI 產生的多語商品名稱，讓市集跟著使用者語系顯示。
+- 賣家可以使用 AI 定價建議，估算合理的二手售價。
+
+## 為什麼需要它
+
+校園二手交易常散落在聊天群組、社群貼文和試算表裡，導致搜尋、比較、追蹤請求與安全交換聯絡方式都不方便。
+
+OSUTrade 將這些流程集中在同一個地方：
+
+- **對買家：** 瀏覽可購買商品、指定需要的數量，並追蹤交易請求狀態。
+- **對賣家：** 管理刊登商品、掌握庫存，並在同一個 Dashboard 回覆買家。
+- **對社群：** 讓物品重複使用更簡單，減少浪費，也讓實惠商品在在地社群中流通。
+
+## 核心功能
+
+| 區塊 | 功能 |
+| --- | --- |
+| 市集 | 瀏覽商品、查看詳情、依在地化商品名稱搜尋，並依分類篩選。 |
+| 商品刊登 | 建立包含價格、分類、圖片、數量與狀態的商品。 |
+| 購買請求購物車 | 在聯絡賣家前，先將商品加入類似購物車的請求流程。 |
+| 數量限制 | 買家不能請求超過賣家目前庫存的數量。 |
+| 買家請求 | 追蹤已送出、已接受、已拒絕與已取消的請求。 |
+| 賣家 Dashboard | 管理商品、更新狀態，並處理買家請求。 |
+| 安全聯絡流程 | 只有在賣家接受請求後，買賣雙方 email 才會顯示。 |
+| 多語系 | 支援英文、繁體中文與簡體中文切換。 |
+| AI 翻譯 | 新商品名稱可翻譯成支援語言並存入 Supabase。 |
+| AI 定價建議 | 依據本地市場訊號與新品價格脈絡，建議二手售價。 |
+| API 文件 | 可透過 Swagger UI 探索 API。 |
+
+## 產品流程
+
+### 買家
+
+1. 瀏覽市集。
+2. 開啟商品詳情頁。
+3. 將商品與數量加入購買請求購物車。
+4. 加入給賣家的備註。
+5. 送出請求。
+6. 從 **Requests** 追蹤請求狀態。
+7. 如果請求被接受，使用顯示出的賣家 email 安排取貨或交易。
+
+### 賣家
+
+1. 從 **Sell** 建立商品刊登。
+2. 視需要使用 AI 定價建議。
+3. 透過多語市集體驗確認商品名稱翻譯。
+4. 從 **Seller** 管理庫存與商品狀態。
+5. 接受或拒絕買家請求。
+6. 只在接受請求後分享聯絡資訊。
+
+## 技術架構
+
+- **Framework:** Next.js 15, React 19, TypeScript
+- **UI:** Radix UI, Tailwind CSS, lucide-react
+- **Auth & Database:** Supabase, NextAuth
+- **Testing:** Vitest, Testing Library
+- **AI:** OpenAI API 用於定價建議與商品名稱翻譯
+- **Deployment:** Vercel
+
+## 使用說明
+
+### 1. 安裝依賴
+
+```bash
+npm install
+```
+
+### 2. 建立環境變數
+
+從 `.env.example` 建立 `.env.local`：
+
+```bash
+cp .env.example .env.local
+```
+
+接著填入必要值：
+
+```env
+NEXT_PUBLIC_SUPABASE_URL="https://your-project-ref.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-publishable-or-anon-key"
+SUPABASE_SERVICE_ROLE_KEY="your-server-only-service-role-key"
+AUTH_SECRET="your-auth-secret"
+AUTH_BASE_URL="http://localhost:3000"
+ENABLE_DEMO_PRODUCTS="false"
+OPENAI_API_KEY=""
+OPENAI_PRICING_MODEL="gpt-4.1-mini"
+OPENAI_TRANSLATION_MODEL="gpt-4.1-mini"
+```
+
+注意事項：
+
+- `OPENAI_API_KEY` 對本機 UI 測試是選填，但 AI 定價與翻譯功能需要它。
+- 請使用新的私密金鑰，且不要把任何 secret commit 到 repository。
+- `SUPABASE_SERVICE_ROLE_KEY` 只能在 server-side 使用。
+
+### 3. 建立 Supabase schema
+
+執行以下 SQL 檔：
+
+```text
+supabase/mvp-schema.sql
+```
+
+至少商品翻譯功能需要：
+
+```sql
+alter table public.products
+  add column if not exists name_en text,
+  add column if not exists name_zh_tw text,
+  add column if not exists name_zh_cn text;
+```
+
+### 4. 啟動本機開發伺服器
+
+```bash
+npm run dev
+```
+
+開啟：
+
+```text
+http://localhost:3000
+```
+
+## 常用指令
+
+```bash
+npm run dev
+npm run build
+npm run start
+npm test -- --run
+```
+
+## 主要路由
+
+| 路由 | 用途 |
+| --- | --- |
+| `/` | 產品首頁與入口。 |
+| `/overview` | 市集瀏覽體驗。 |
+| `/product/[id]` | 商品詳情與加入購買請求流程。 |
+| `/sell` | 賣家刊登表單與 AI 定價建議。 |
+| `/cart` | 購買請求購物車與買家請求送出。 |
+| `/requests` | 買家請求追蹤。 |
+| `/seller` | 賣家 Dashboard，管理商品與收到的請求。 |
+| `/docs/swagger` | API 文件。 |
+
+## 作者介紹
+
+**Barry Chung**
+
+Barry Chung 是 OSUTrade 的創作者，將這個專案打造為一個實用的校園二手交易 full-stack marketplace。專案結合產品思維、marketplace UX、Supabase 工作流程、多語系支援，以及 AI 輔助賣家工具。
+
+- GitHub: [barrychung1112](https://github.com/barrychung1112)
+- Project: [OSUTrade](https://github.com/barrychung1112/OSUTrade)
+- Discord: [OSUTrade Community](https://discord.gg/BqqAmmjJR)
+- Support: [Buy Me a Coffee](https://buymeacoffee.com/osutrade)
+
+## 願景
+
+OSUTrade 目標成為一個輕量、可信任的在地校園 marketplace：足夠簡單，讓使用者能快速刊登；足夠有結構，能支援認真的交易流程；也足夠貼心，在雙方準備好聯絡之前保護使用者資訊。


### PR DESCRIPTION
## Summary
- Add a language switcher to the English README.
- Add Traditional Chinese and Simplified Chinese README versions with matching project, author, and usage sections.
- Keep GitHub, Discord, and Buy Me a Coffee links available across all README languages.

## Validation
- `git diff --check`