### PR TITLE
Unify empty state feedback

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -18,6 +18,7 @@ import {
   TrashIcon,
 } from "@radix-ui/react-icons";
 import Header from "../components/Header";
+import EmptyState from "../components/EmptyState";
 import { useI18n } from "../i18n";
 import { pickProductName, type ProductNameTranslations } from "../lib/productTranslations";
 
@@ -188,19 +189,15 @@ export default function CartPage() {
                   <Text>{t("cart.loading")}</Text>
                 </Card>
               ) : items.length === 0 ? (
-                <Card className="border border-orange-200 bg-white/60 p-8 text-center shadow">
-                  <Heading size="5" className="mb-2">
-                    {t("cart.empty")}
-                  </Heading>
-                  <Text color="gray">
-                    {t("cart.emptyHelp")}
-                  </Text>
-                  <div className="mt-6">
+                <EmptyState
+                  title={t("cart.empty")}
+                  body={t("cart.emptyHelp")}
+                  action={
                     <Link href="/overview">
                       <Button highContrast>{t("cart.goShopping")}</Button>
                     </Link>
-                  </div>
-                </Card>
+                  }
+                />
               ) : (
                 items.map((item) => (
                   <ItemCard

--- a/app/components/EmptyState.tsx
+++ b/app/components/EmptyState.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { Card, Heading, Text } from "@radix-ui/themes";
+
+export default function EmptyState({
+  title,
+  body,
+  action,
+}: {
+  title: string;
+  body: string;
+  action?: ReactNode;
+}) {
+  return (
+    <Card className="border border-dashed border-orange-200 bg-white/70 px-6 py-10 text-center shadow-sm">
+      <Heading size="4" className="text-gray-950">
+        {title}
+      </Heading>
+      <Text as="p" color="gray" className="mx-auto mt-2 max-w-sm">
+        {body}
+      </Text>
+      {action && <div className="mt-5 flex justify-center">{action}</div>}
+    </Card>
+  );
+}

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Button, Heading, Theme } from "@radix-ui/themes";
 import Header from "../components/Header";
+import EmptyState from "../components/EmptyState";
 import ProductCard from "../components/ProductCard";
 import { useProducts } from "../hook/useProducts";
 import type { Product } from "../lib/products";
@@ -184,13 +185,20 @@ export default function ProductListPage() {
                 />
               ))
             ) : (
-              <div className="col-span-full rounded-lg border border-dashed border-orange-200 bg-white/60 px-6 py-12 text-center">
-                <Heading size="4" className="text-gray-900">
-                  {t("marketplace.noMatches")}
-                </Heading>
-                <p className="mt-2 text-sm text-gray-600">
-                  {t("marketplace.noMatchesHelp")}
-                </p>
+              <div className="col-span-full">
+                <EmptyState
+                  title={t("marketplace.noMatches")}
+                  body={t("marketplace.noMatchesHelp")}
+                  action={
+                    <Button
+                      variant="soft"
+                      onClick={clearFilters}
+                      disabled={!hasFilters}
+                    >
+                      {t("common.clear")}
+                    </Button>
+                  }
+                />
               </div>
             )}
           </section>

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Badge, Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
 import { ArrowLeftIcon } from "@radix-ui/react-icons";
 import Header from "../components/Header";
+import EmptyState from "../components/EmptyState";
 import { useI18n } from "../i18n";
 import { pickProductName, type ProductNameTranslations } from "../lib/productTranslations";
 
@@ -141,31 +142,23 @@ export default function RequestsPage() {
             {loading ? (
               <Card className="p-5">{t("requests.loading")}</Card>
             ) : requests.length === 0 ? (
-              <Card className="p-8 text-center">
-                <Heading size="5" className="mb-2">
-                  {t("requests.empty")}
-                </Heading>
-                <Text color="gray">
-                  {t("requests.emptyHelp")}
-                </Text>
-                <div className="mt-5">
+              <EmptyState
+                title={t("requests.empty")}
+                body={t("requests.emptyHelp")}
+                action={
                   <Link href="/overview">
                     <Button highContrast>{t("requests.browse")}</Button>
                   </Link>
-                </div>
-              </Card>
+                }
+              />
             ) : filteredRequests.length === 0 ? (
-              <Card className="p-8 text-center">
-                <Heading size="5" className="mb-2">
-                  {t("requests.noFiltered")}
-                </Heading>
-                <Text color="gray">
-                  {t("requests.counts", {
+              <EmptyState
+                title={t("requests.noFiltered")}
+                body={t("requests.counts", {
                     total: requests.length,
                     accepted: acceptedCount,
                   })}
-                </Text>
-              </Card>
+              />
             ) : (
               filteredRequests.map((request) => (
                 <RequestCard

--- a/app/seller/page.tsx
+++ b/app/seller/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Badge, Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
 import { ArrowLeftIcon, CheckIcon, Cross2Icon, PlusIcon } from "@radix-ui/react-icons";
 import Header from "../components/Header";
+import EmptyState from "../components/EmptyState";
 import { useI18n } from "../i18n";
 import { pickProductName, type ProductNameTranslations } from "../lib/productTranslations";
 
@@ -315,28 +316,6 @@ function StatCard({ label, value }: { label: string; value: number }) {
         {label}
       </Text>
       <p className="mt-1 text-2xl font-bold text-gray-950">{value}</p>
-    </div>
-  );
-}
-
-function EmptyState({
-  title,
-  body,
-  action,
-}: {
-  title: string;
-  body: string;
-  action: ReactNode;
-}) {
-  return (
-    <div className="rounded-lg border border-dashed border-orange-200 bg-white/70 px-6 py-10 text-center">
-      <Heading size="4" className="text-gray-950">
-        {title}
-      </Heading>
-      <Text as="p" color="gray" className="mx-auto mt-2 max-w-sm">
-        {body}
-      </Text>
-      <div className="mt-5 flex justify-center">{action}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a shared `EmptyState` component for consistent empty screens.
- Apply the empty state pattern to cart, buyer requests, marketplace search results, and seller dashboard panels.
- Keep each empty state action-oriented with the next relevant CTA.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- `git diff --check`
- Browser note: unauthenticated `/overview` redirects to `/?from=/overview`, so protected-page empty states were validated through build/type checks in this PR.