### PR TITLE
Fix header language toggle width

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -103,7 +103,7 @@ export default function Header() {
           </Link>
         </nav>
 
-        <div className="flex min-w-[190px] shrink-0 items-center justify-end gap-2">
+        <div className="flex min-w-max shrink-0 items-center justify-end gap-2">
           <LanguageToggle />
           <div className="hidden sm:block lg:hidden">{authControl}</div>
           <button

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -720,11 +720,10 @@ export function LanguageToggle() {
 
   return (
     <div
-      className="inline-flex min-w-[138px] shrink-0 rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
+      className="inline-flex shrink-0 rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
       style={{
         flexShrink: 0,
-        minWidth: "138px",
-        width: "138px",
+        width: "fit-content",
         boxSizing: "border-box",
       }}
       aria-label={t("common.language")}


### PR DESCRIPTION
## Summary
- Remove the fixed 138px language toggle width so it can size to its content.
- Restore the header right control group to content-based width instead of a fixed 190px minimum.
- Keep the toggle from shrinking while avoiding unnecessary horizontal pressure in narrow layouts.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- `git diff --check`
- Browser check on `http://127.0.0.1:3001/overview` confirmed the language toggle renders with content width (~119.55px) and `min-width: auto`.