### PR TITLE
Fix header avatar control width

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -59,7 +59,7 @@ export default function Header() {
         <Avatar
           fallback={fallback.toUpperCase()}
           size="2"
-          className="cursor-pointer border border-gray-300"
+          className="header-avatar-control cursor-pointer border border-gray-300"
         />
       </DropdownMenu.Trigger>
       <DropdownMenu.Content align="end">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,20 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.header-avatar-control {
+  flex-shrink: 0;
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  box-sizing: border-box;
+}
+
+.header-avatar-control .rt-AvatarFallback {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 100% !important;
+  height: 100%;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- Add a dedicated header avatar class so the user fallback control keeps a stable 36px square size.
- Override the Radix avatar fallback inline width so the single-letter user button no longer collapses in the header.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- `git diff --check`
- Local browser check confirmed the compiled CSS includes `header-avatar-control` rules.