### PR TITLE
Refine secondary UI surfaces

### DIFF
--- a/app/components/LoginModal.tsx
+++ b/app/components/LoginModal.tsx
@@ -60,7 +60,7 @@ export default function LoginModal() {
           <form onSubmit={onSubmit}>
             <Flex direction="column" gap="3" mt="4">
               <input
-                className="px-3 py-2 border rounded"
+                className="app-input"
                 placeholder={t("auth.email")}
                 type="email"
                 autoComplete="email"
@@ -70,7 +70,7 @@ export default function LoginModal() {
               />
               <input
                 type="password"
-                className="px-3 py-2 border rounded"
+                className="app-input"
                 placeholder={t("auth.password")}
                 autoComplete="current-password"
                 value={password}

--- a/app/components/OnlineUsersCard.tsx
+++ b/app/components/OnlineUsersCard.tsx
@@ -47,9 +47,11 @@ export default function OnlineUsersCard() {
   }, []);
 
   return (
-    <Card className="border border-orange-200 bg-white/60 p-4 shadow backdrop-blur-md transition-transform hover:scale-[1.02]">
+    <Card className="app-card p-4 backdrop-blur">
       <div className="flex items-center gap-3">
-        <PersonIcon />
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-orange-50 text-[#d73f09]">
+          <PersonIcon />
+        </div>
         <div>
           <Text size="2" color="gray">
             {t("home.onlineNow")}

--- a/app/components/SignUpModal.tsx
+++ b/app/components/SignUpModal.tsx
@@ -88,7 +88,7 @@ export default function SignUpModal() {
           <form onSubmit={onSubmit}>
             <Flex direction="column" gap="3" mt="4">
               <input
-                className="px-3 py-2 border rounded"
+                className="app-input"
                 placeholder={t("auth.email")}
                 type="email"
                 autoComplete="email"
@@ -97,7 +97,7 @@ export default function SignUpModal() {
                 required
               />
               <input
-                className="px-3 py-2 border rounded"
+                className="app-input"
                 placeholder={t("auth.username")}
                 autoComplete="name"
                 value={username}
@@ -106,7 +106,7 @@ export default function SignUpModal() {
               />
               <input
                 type="password"
-                className="px-3 py-2 border rounded"
+                className="app-input"
                 placeholder={t("auth.password")}
                 autoComplete="new-password"
                 value={password}

--- a/app/components/TimezoneCards.tsx
+++ b/app/components/TimezoneCards.tsx
@@ -58,11 +58,13 @@ export default function TimezoneCards() {
       {timezones.map(({ label, code }) => (
         <Card
           key={label}
-          className="border border-orange-200 bg-white/60 p-4 shadow backdrop-blur-md transition-transform hover:scale-[1.02]"
+          className="app-card p-4 backdrop-blur"
         >
           <div className="flex items-start gap-3">
-            <ClockIcon className="mt-1" />
-            <div className="flex flex-col">
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-orange-50 text-[#d73f09]">
+              <ClockIcon />
+            </div>
+            <div className="flex min-w-0 flex-col">
               <Text size="2" color="gray">
                 {code} - {label} Time
               </Text>

--- a/app/docs/swagger/page.tsx
+++ b/app/docs/swagger/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { Theme } from "@radix-ui/themes";
 import "swagger-ui-react/swagger-ui.css";
 import { ComponentType } from "react";
+import Header from "../../components/Header";
 
-// 明確註明元件的 props 型別
 const SwaggerUI = dynamic(
   () => import("swagger-ui-react") as Promise<ComponentType<{ url: string }>>,
   {
@@ -14,15 +15,24 @@ const SwaggerUI = dynamic(
 
 export default function SwaggerDocsPage() {
   return (
-    <main className="min-h-screen bg-white px-4 py-10">
-      <h1 className="text-3xl font-bold mb-6 text-center text-gray-800">
-        📘 Product API Swagger Docs
-      </h1>
-      <div className="bg-white border rounded shadow-xl p-4">
-        <SwaggerUI url="/docs/products-api.swagger.json" />
-        <SwaggerUI url="/docs/signup-api.json" />
-        <SwaggerUI url="/docs/login-api.json" />
-      </div>
-    </main>
+    <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <main className="app-page">
+        <Header />
+        <section className="app-container">
+          <div className="app-hero">
+            <p className="app-eyebrow">API</p>
+            <h1 className="app-title">Product API Swagger Docs</h1>
+            <p className="app-subtitle">
+              Review the current product, signup, and login API contracts.
+            </p>
+          </div>
+          <div className="app-card overflow-hidden p-4">
+            <SwaggerUI url="/docs/products-api.swagger.json" />
+            <SwaggerUI url="/docs/signup-api.json" />
+            <SwaggerUI url="/docs/login-api.json" />
+          </div>
+        </section>
+      </main>
+    </Theme>
   );
 }

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -160,7 +160,7 @@ export default function ProductListPage() {
 
           <section className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {loading ? (
-              <div className="col-span-full rounded-lg border border-dashed border-orange-200 bg-white/60 px-6 py-12 text-center text-gray-600">
+              <div className="col-span-full rounded-lg border border-dashed border-orange-200 bg-white/85 px-6 py-12 text-center text-gray-600 shadow-sm">
                 {t("marketplace.loadingListings")}
               </div>
             ) : filteredProducts.length > 0 ? (

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -131,7 +131,7 @@ export default function RequestsPage() {
                 className={`app-chip ${
                   filter === item
                     ? "border-[#d73f09] bg-[#d73f09] text-white"
-                    : "border-orange-200 bg-white/70 text-gray-700 hover:bg-orange-50"
+                    : "border-orange-200 bg-white/85 text-gray-700 hover:bg-orange-50"
                 }`}
               >
                 {t(`requests.filter.${item}` as any)}


### PR DESCRIPTION
## Summary
- Bring login and signup modal inputs into the shared app input style.
- Polish homepage presence and timezone cards to match the quieter app card system.
- Update marketplace loading and request filter chips for better visual consistency.
- Bring Swagger docs into the app shell with header, hero copy, and lighter card styling.

## Validation
- `npm.cmd test -- --run`
- `npm.cmd run build`
- `git diff --check`
- HTTP render checks: `/`, `/docs/swagger`, and `/product/demo-bike` returned 200 with the shared `app-page` shell and no `useThemeContext` content.