### PR TITLE
Make request action buttons clearer

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -13,8 +13,10 @@ import {
 } from "@radix-ui/themes";
 import {
   ArrowLeftIcon,
+  CheckIcon,
   MinusIcon,
   PlusIcon,
+  RocketIcon,
   TrashIcon,
 } from "@radix-ui/react-icons";
 import Header from "../components/Header";
@@ -241,7 +243,9 @@ export default function CartPage() {
                   body={t("cart.emptyHelp")}
                   action={
                     <Link href="/overview">
-                      <Button highContrast>{t("cart.goShopping")}</Button>
+                      <Button highContrast>
+                        <ArrowLeftIcon /> {t("cart.goShopping")}
+                      </Button>
                     </Link>
                   }
                 />
@@ -296,6 +300,7 @@ export default function CartPage() {
                   onClick={sendAll}
                   disabled={items.length === 0 || allSent}
                 >
+                  {allSent ? <CheckIcon /> : <RocketIcon />}
                   {allSent ? t("cart.allSent") : t("cart.sendAll")}
                 </Button>
               </Card>
@@ -357,11 +362,11 @@ function ItemCard({
 
             <button
               onClick={onRemove}
-              className="inline-flex items-center gap-1 text-red-600 transition-colors hover:text-red-700"
+              className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 text-sm font-semibold text-red-700 transition hover:border-red-300 hover:bg-red-100"
               aria-label={t("cart.remove")}
               title={t("cart.remove")}
             >
-              <TrashIcon /> <span className="text-sm">{t("cart.remove")}</span>
+              <TrashIcon /> <span>{t("cart.remove")}</span>
             </button>
           </div>
 
@@ -369,19 +374,21 @@ function ItemCard({
             <div className="inline-flex items-center overflow-hidden rounded-lg border border-gray-300 bg-white">
               <button
                 onClick={onMinus}
-                className="p-2 transition hover:bg-gray-50 active:scale-95"
+                className="flex h-10 w-10 items-center justify-center transition hover:bg-gray-50 active:scale-95"
                 aria-label={t("cart.decrease")}
               >
                 <MinusIcon />
               </button>
-              <span className="px-4 select-none">{item.quantity}</span>
+              <span className="min-w-10 select-none px-3 text-center font-semibold">
+                {item.quantity}
+              </span>
               <button
                 onClick={onPlus}
                 disabled={
                   Number.isInteger(item.availableQuantity) &&
                   item.quantity >= Number(item.availableQuantity)
                 }
-                className="p-2 transition hover:bg-gray-50 active:scale-95"
+                className="flex h-10 w-10 items-center justify-center transition hover:bg-gray-50 active:scale-95 disabled:cursor-not-allowed disabled:opacity-45"
                 aria-label={t("cart.increase")}
               >
                 <PlusIcon />
@@ -424,10 +431,13 @@ function ItemCard({
             </div>
 
             <Button
+              size="3"
               highContrast
+              className="min-w-full sm:min-w-[168px]"
               disabled={disabled || state?.status === "sent"}
               onClick={onSend}
             >
+              {state?.status === "sent" || requestBlocked ? <CheckIcon /> : <RocketIcon />}
               {state?.status === "sending"
                 ? t("cart.sending")
                 : state?.status === "sent" || requestBlocked
@@ -436,11 +446,10 @@ function ItemCard({
             </Button>
           </div>
           {(state?.status === "sent" || requestBlocked) && (
-            <Link
-              href="/requests"
-              className="mt-3 inline-flex text-sm font-semibold text-[#d73f09] underline-offset-4 hover:underline"
-            >
-              {t("cart.viewRequests")}
+            <Link href="/requests" className="mt-3 inline-flex">
+              <Button variant="soft" size="2">
+                <ArrowLeftIcon /> {t("cart.viewRequests")}
+              </Button>
             </Link>
           )}
         </div>

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Button, Heading, Theme } from "@radix-ui/themes";
+import { Cross2Icon, PlusIcon, ReloadIcon } from "@radix-ui/react-icons";
 import Header from "../components/Header";
 import EmptyState from "../components/EmptyState";
 import ProductCard from "../components/ProductCard";
@@ -77,10 +78,13 @@ export default function ProductListPage() {
 
             <div className="flex flex-wrap gap-2">
               <Button variant="soft" onClick={() => refetch()} disabled={loading}>
+                <ReloadIcon />
                 {loading ? t("common.refreshing") : t("common.refresh")}
               </Button>
               <Link href="/sell">
-                <Button highContrast>{t("marketplace.listItem")}</Button>
+                <Button highContrast>
+                  <PlusIcon /> {t("marketplace.listItem")}
+                </Button>
               </Link>
             </div>
           </section>
@@ -146,6 +150,7 @@ export default function ProductListPage() {
                 disabled={!hasFilters}
                 className="h-10"
               >
+                <Cross2Icon />
                 {t("common.clear")}
               </Button>
             </div>
@@ -195,6 +200,7 @@ export default function ProductListPage() {
                       onClick={clearFilters}
                       disabled={!hasFilters}
                     >
+                      <Cross2Icon />
                       {t("common.clear")}
                     </Button>
                   }

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Badge, Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
-import { ArrowLeftIcon } from "@radix-ui/react-icons";
+import { ArrowLeftIcon, Cross2Icon } from "@radix-ui/react-icons";
 import Header from "../components/Header";
 import EmptyState from "../components/EmptyState";
 import { useI18n } from "../i18n";
@@ -205,7 +205,9 @@ export default function RequestsPage() {
                 body={t("requests.emptyHelp")}
                 action={
                   <Link href="/overview">
-                    <Button highContrast>{t("requests.browse")}</Button>
+                    <Button highContrast>
+                      <ArrowLeftIcon /> {t("requests.browse")}
+                    </Button>
                   </Link>
                 }
               />
@@ -311,8 +313,13 @@ function RequestCard({
           <RequestProgress status={request.status} t={t} />
 
           {request.status === "sent" && (
-            <Button className="mt-4" color="red" variant="soft" onClick={onCancel}>
-              {t("requests.cancel")}
+            <Button
+              className="mt-4"
+              color="red"
+              variant="soft"
+              onClick={onCancel}
+            >
+              <Cross2Icon /> {t("requests.cancel")}
             </Button>
           )}
         </div>

--- a/app/sell/page.tsx
+++ b/app/sell/page.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
+import { CheckIcon, PlusIcon } from "@radix-ui/react-icons";
 import Header from "../components/Header";
 import type { Product } from "../lib/products";
 import { useI18n } from "../i18n";
@@ -202,10 +203,10 @@ export default function SellPage() {
               </Text>
               <div className="mt-4 flex flex-wrap gap-3">
                 <Button type="button" highContrast onClick={goToProductNow}>
-                  {t("sell.viewListing")}
+                  <CheckIcon /> {t("sell.viewListing")}
                 </Button>
                 <Button type="button" variant="soft" onClick={listAnotherItem}>
-                  {t("sell.listAnother")}
+                  <PlusIcon /> {t("sell.listAnother")}
                 </Button>
                 <Link href="/seller">
                   <Button type="button" variant="outline">
@@ -277,6 +278,7 @@ export default function SellPage() {
                     disabled={pricingLoading || !name.trim()}
                     className="whitespace-nowrap"
                   >
+                    <CheckIcon />
                     {pricingLoading
                       ? t("sell.pricingAdvisorLoading")
                       : t("sell.pricingAdvisor")}
@@ -313,6 +315,7 @@ export default function SellPage() {
                         highContrast
                         onClick={() => setPrice(String(pricingAdvice.suggestedPrice))}
                       >
+                        <CheckIcon />
                         {t("sell.pricingAdvisorApply")}
                       </Button>
                     </div>
@@ -459,7 +462,8 @@ export default function SellPage() {
                 </p>
               )}
 
-              <Button highContrast type="submit" disabled={loading}>
+              <Button highContrast size="3" type="submit" disabled={loading}>
+                <PlusIcon />
                 {loading ? t("sell.listing") : t("sell.submit")}
               </Button>
             </form>


### PR DESCRIPTION
## Summary
- strengthen request cart actions with clearer icon buttons and fixed tap targets
- add icons and stronger CTA treatment to request, marketplace, and sell-page actions
- keep this change scoped to UI affordance and button presentation only

## Validation
- npm.cmd test -- --run
- npm.cmd run build
- git diff --check