### PR TITLE
Show login prompt after protected redirect

### DIFF
--- a/app/components/LoginModal.tsx
+++ b/app/components/LoginModal.tsx
@@ -6,7 +6,7 @@ import { signIn } from "next-auth/react";
 import { Dialog, Flex, Button } from "@radix-ui/themes";
 import { useI18n } from "../i18n";
 
-export default function LoginModal() {
+export default function LoginModal({ redirectTo = "/overview" }: { redirectTo?: string }) {
   const { t } = useI18n();
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
@@ -34,7 +34,7 @@ export default function LoginModal() {
     }
 
     setIsOpen(false);
-    router.push("/overview");
+    router.push(redirectTo);
     router.refresh();
   }
 

--- a/app/components/SignUpModal.tsx
+++ b/app/components/SignUpModal.tsx
@@ -13,7 +13,7 @@ type SignupResponse = {
   status?: "confirmation_required";
 };
 
-export default function SignUpModal() {
+export default function SignUpModal({ redirectTo = "/overview" }: { redirectTo?: string }) {
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState(false);
   const [email, setEmail] = useState("");
@@ -61,7 +61,7 @@ export default function SignUpModal() {
       return;
     }
 
-    window.location.assign("/overview");
+    window.location.assign(redirectTo);
   }
 
   return (

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -50,6 +50,8 @@ const dictionaries = {
     "auth.signupError": "Sign up failed. Check your email and password.",
     "auth.confirmEmail": "Please check your email to confirm your account.",
     "auth.createdConfirm": "Account created. Please log in after confirming your email.",
+    "auth.requiredTitle": "Log in to continue",
+    "auth.requiredBody": "Please log in or create an account to continue to {destination}.",
     "home.description":
       "Looking to declutter or find great deals? OSUTrade helps you list secondhand items, browse campus listings, and send requests to sellers in a few clicks.",
     "home.github": "GitHub",
@@ -297,6 +299,8 @@ const dictionaries = {
     "auth.signupError": "註冊失敗，請確認 email 與密碼。",
     "auth.confirmEmail": "請查看信箱並完成帳號驗證。",
     "auth.createdConfirm": "帳號已建立。請完成 email 驗證後再登入。",
+    "auth.requiredTitle": "請先登入以繼續",
+    "auth.requiredBody": "請登入或建立帳號後繼續前往「{destination}」。",
     "home.description":
       "想出清閒置物品或找划算好物嗎？OSUTrade 讓你可以刊登二手商品、瀏覽校園市集，並快速向賣家送出交易需求。",
     "home.github": "GitHub",
@@ -548,6 +552,8 @@ const zhCnDictionary: Record<TranslationKey, string> = {
   "auth.signupError": "注册失败，请确认 email 与密码。",
   "auth.confirmEmail": "请查看邮箱并完成账号验证。",
   "auth.createdConfirm": "账号已创建。请完成 email 验证后再登录。",
+  "auth.requiredTitle": "请先登录以继续",
+  "auth.requiredBody": "请登录或创建账号后继续前往「{destination}」。",
   "home.description":
     "想清理闲置物品或找到划算好物吗？OSUTrade 让你可以刊登二手商品、浏览校园市集，并快速向卖家发送交易需求。",
   "home.github": "GitHub",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,8 +58,8 @@ export default function HomePage() {
                   {t("auth.requiredBody", { destination: redirectLabel })}
                 </Text>
                 <div className="mt-4 flex flex-wrap gap-3">
-                  <LoginModal />
-                  <SignUpModal />
+                  <LoginModal redirectTo={redirectPath} />
+                  <SignUpModal redirectTo={redirectPath} />
                 </div>
               </Card>
             )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "@radix-ui/themes/styles.css";
+import { useEffect, useMemo, useState } from "react";
 import { Theme, Heading, Text, Button, Card } from "@radix-ui/themes";
 import {
   GitHubLogoIcon,
@@ -20,6 +21,22 @@ import { useI18n } from "./i18n";
 
 export default function HomePage() {
   const { t } = useI18n();
+  const [redirectPath, setRedirectPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    const from = new URLSearchParams(window.location.search).get("from");
+    setRedirectPath(from);
+  }, []);
+
+  const redirectLabel = useMemo(() => {
+    if (!redirectPath) return "";
+    if (redirectPath.startsWith("/sell")) return t("nav.sell");
+    if (redirectPath.startsWith("/seller")) return t("nav.seller");
+    if (redirectPath.startsWith("/cart")) return t("nav.cart");
+    if (redirectPath.startsWith("/requests")) return t("nav.requests");
+    if (redirectPath.startsWith("/overview")) return t("nav.marketplace");
+    return "OSUTrade";
+  }, [redirectPath, t]);
 
   return (
     <Theme
@@ -32,6 +49,21 @@ export default function HomePage() {
         <Header />
         <div className="app-container grid grid-cols-1 gap-6 align-middle xl:grid-cols-3">
           <div className="col-span-1 flex flex-col gap-6">
+            {redirectPath && (
+              <Card className="app-card border-amber-200 bg-amber-50 p-4">
+                <Text size="2" weight="bold" className="text-amber-950">
+                  {t("auth.requiredTitle")}
+                </Text>
+                <Text size="2" className="mt-1 block leading-6 text-amber-900">
+                  {t("auth.requiredBody", { destination: redirectLabel })}
+                </Text>
+                <div className="mt-4 flex flex-wrap gap-3">
+                  <LoginModal />
+                  <SignUpModal />
+                </div>
+              </Card>
+            )}
+
             <div className="app-hero mb-0">
               <Text
                 size="2"


### PR DESCRIPTION
## Summary
- show a clear login-required prompt on the home page when protected routes redirect back with a from parameter
- identify the destination in the prompt so users know which action was blocked
- add English, Traditional Chinese, and Simplified Chinese copy

## Validation
- npm.cmd test -- --run
- npm.cmd run build
- git diff --check
- browser check: http://localhost:3000/?from=/sell shows the login-required prompt