### PR TITLE
Stabilize header language controls

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -60,6 +60,14 @@ export default function Header() {
           fallback={fallback.toUpperCase()}
           size="2"
           className="header-avatar-control cursor-pointer border border-gray-300"
+          style={{
+            display: "inline-flex",
+            flexShrink: 0,
+            width: 36,
+            minWidth: 36,
+            height: 36,
+            minHeight: 36,
+          }}
         />
       </DropdownMenu.Trigger>
       <DropdownMenu.Content align="end">

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,10 +45,9 @@
 }
 
 .header-avatar-control {
-  flex-shrink: 0;
-  width: 36px;
-  min-width: 36px;
-  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   box-sizing: border-box;
 }
 

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -853,18 +853,13 @@ export function LanguageToggle() {
 
   return (
     <div
-      className="inline-flex shrink-0 rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
-      style={{
-        flexShrink: 0,
-        width: "fit-content",
-        boxSizing: "border-box",
-      }}
+      className="inline-flex w-fit shrink-0 items-center rounded-md border border-orange-200 bg-white/80 p-0.5 text-xs font-semibold shadow-sm"
       aria-label={t("common.language")}
     >
       <button
         type="button"
         onClick={() => setLocale("en")}
-        className={`rounded px-2 py-1 transition ${
+        className={`min-h-8 min-w-10 rounded px-2 py-1 text-center transition ${
           locale === "en" ? "bg-[#d73f09] text-white" : "text-gray-700"
         }`}
       >
@@ -873,7 +868,7 @@ export function LanguageToggle() {
       <button
         type="button"
         onClick={() => setLocale("zh")}
-        className={`rounded px-2 py-1 transition ${
+        className={`min-h-8 min-w-12 rounded px-2 py-1 text-center transition ${
           locale === "zh" ? "bg-[#d73f09] text-white" : "text-gray-700"
         }`}
       >
@@ -882,7 +877,7 @@ export function LanguageToggle() {
       <button
         type="button"
         onClick={() => setLocale("zhCn")}
-        className={`rounded px-2 py-1 transition ${
+        className={`min-h-8 min-w-12 rounded px-2 py-1 text-center transition ${
           locale === "zhCn" ? "bg-[#d73f09] text-white" : "text-gray-700"
         }`}
       >


### PR DESCRIPTION
## Summary
- Replaced inline sizing on the language switcher with stable Tailwind classes.
- Gave each language button a fixed minimum hit target and centered text.
- Hardened the header avatar control with explicit display, width, height, and text alignment rules.

## Validation
- `npm.cmd test -- --run`
- `npx.cmd tsc --noEmit`
- `npx.cmd next build --debug`
- `git diff --check`
- Browser measurement: language buttons render at 40/48/48px wide, 32px tall, centered, with no horizontal overflow.