### PR TITLE
Fix marketplace clear button layout

### DIFF
--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -154,10 +154,11 @@ export default function ProductListPage() {
                 type="button"
                 onClick={clearFilters}
                 disabled={!hasFilters}
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-orange-200 bg-white px-3 text-sm font-semibold text-gray-700 shadow-sm transition hover:bg-orange-50 hover:text-[#d73f09] disabled:cursor-not-allowed disabled:opacity-50 md:min-w-24"
+                className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-orange-200 bg-white text-gray-700 shadow-sm transition hover:bg-orange-50 hover:text-[#d73f09] disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={t("common.clear")}
+                title={t("common.clear")}
               >
                 <Cross2Icon />
-                {t("common.clear")}
               </button>
             </div>
 
@@ -208,7 +209,7 @@ export default function ProductListPage() {
                       className="inline-flex h-11 min-w-32 items-center justify-center gap-2 rounded-md border border-orange-200 bg-white px-4 text-sm font-semibold text-[#d73f09] shadow-sm transition hover:bg-orange-50 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Cross2Icon />
-                      {t("common.clear")}
+                      <span className="whitespace-nowrap">{t("common.clear")}</span>
                     </button>
                   }
                 />


### PR DESCRIPTION
## Summary
- Changed the filter-row Clear action to a fixed-size icon-only button with aria/title text.
- Prevented the empty-state Clear label from wrapping vertically.
- Kept the existing clear filter behavior unchanged.

## Validation
- `npm.cmd test -- --run`
- `npx.cmd tsc --noEmit`
- `npx.cmd next build --debug`
- `git diff --check`
