### PR TITLE
Require explicit demo product fallback

### DIFF
--- a/app/lib/demoProducts.ts
+++ b/app/lib/demoProducts.ts
@@ -84,10 +84,7 @@ export const demoProducts: DemoProduct[] = [
 ];
 
 export function canUseDemoProducts() {
-  return (
-    process.env.NODE_ENV !== "production" ||
-    process.env.ENABLE_DEMO_PRODUCTS === "true"
-  );
+  return process.env.ENABLE_DEMO_PRODUCTS === "true";
 }
 
 export function filterDemoProducts({


### PR DESCRIPTION
## Summary
- Require demo product fallback to be explicitly enabled with `ENABLE_DEMO_PRODUCTS=true`
- Prevent local or launch builds from showing placeholder products by default
- Confirmed production API currently returns an empty product list

## Validation
- `npm.cmd test -- --run`
- `npx.cmd tsc --noEmit`
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx.cmd next build --debug`
- `https://osutrade.com/api/products` returns `data: []`
