### PR TITLE
Fix product translation and mobile logout layout

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -50,6 +50,44 @@ function toProduct(row: ProductRow) {
   };
 }
 
+const schemaOptionalFields = [
+  "description",
+  "name_en",
+  "name_zh_tw",
+  "name_zh_cn",
+  "image_urls",
+  "contact_phone",
+  "contact_line_id",
+  "contact_wechat_id",
+] as const;
+
+function withoutUnsupportedSchemaField<T extends Record<string, unknown>>(
+  values: T,
+  message: string
+) {
+  const nextValues = { ...values };
+  const normalizedMessage = message.toLowerCase();
+  let removedField = false;
+
+  for (const field of schemaOptionalFields) {
+    if (normalizedMessage.includes(field)) {
+      delete nextValues[field];
+      removedField = true;
+    }
+  }
+
+  if (!removedField && /schema cache|could not find/i.test(message)) {
+    for (const field of schemaOptionalFields) {
+      delete nextValues[field];
+    }
+  }
+
+  return {
+    values: nextValues,
+    changed: Object.keys(nextValues).length !== Object.keys(values).length,
+  };
+}
+
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
@@ -206,34 +244,42 @@ export async function POST(request: NextRequest) {
       status: "available",
     };
 
-    let { data, error } = await supabase
-      .from("products")
-      .insert(insertValues)
-      .select(
-        "product_id, name, description, name_en, name_zh_tw, name_zh_cn, price, category, image_url, image_urls, seller_id, status, quantity"
-      )
-      .single();
+    let currentInsertValues: Record<string, unknown> = insertValues;
+    let data: ProductRow | null = null;
+    let error: any = null;
 
-    if (error && /description|name_(en|zh_tw|zh_cn)|image_urls|contact_(phone|line_id|wechat_id)|schema cache/i.test(error.message ?? "")) {
-      const {
-        description,
-        name_en,
-        name_zh_tw,
-        name_zh_cn,
-        image_urls,
-        contact_phone,
-        contact_line_id,
-        contact_wechat_id,
-        ...legacyValues
-      } = insertValues;
-      const legacyResult = await supabase
+    for (let attempt = 0; attempt <= schemaOptionalFields.length; attempt += 1) {
+      const result = await supabase
         .from("products")
-        .insert(legacyValues)
-        .select("product_id, name, price, category, image_url, seller_id, status, quantity")
+        .insert(currentInsertValues)
+        .select("*")
         .single();
 
-      data = legacyResult.data as any;
-      error = legacyResult.error;
+      data = result.data as ProductRow | null;
+      error = result.error;
+
+      if (!error) {
+        break;
+      }
+
+      if (
+        !/description|name_(en|zh_tw|zh_cn)|image_urls|contact_(phone|line_id|wechat_id)|schema cache|could not find/i.test(
+          error.message ?? ""
+        )
+      ) {
+        break;
+      }
+
+      const fallback = withoutUnsupportedSchemaField(
+        currentInsertValues,
+        error.message ?? ""
+      );
+
+      if (!fallback.changed) {
+        break;
+      }
+
+      currentInsertValues = fallback.values;
     }
 
     if (error) {

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -20,6 +20,53 @@ type HeaderUser = {
   email?: string | null;
 };
 
+type UserMenuProps = {
+  user: HeaderUser;
+  fallback: string;
+  logoutLabel: string;
+  onLogout: () => void;
+};
+
+function UserMenu({ user, fallback, logoutLabel, onLogout }: UserMenuProps) {
+  const displayName = user.name || user.email || "Profile";
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger aria-label={displayName}>
+        <button
+          type="button"
+          className="inline-flex h-11 max-w-full shrink-0 cursor-pointer items-center gap-2 rounded-md border border-gray-300 bg-white px-1.5 pr-3 text-sm font-semibold text-gray-700 shadow-sm transition hover:bg-orange-50 hover:text-[#d73f09] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d73f09] focus-visible:ring-offset-2"
+        >
+          <Avatar
+            fallback={fallback.toUpperCase()}
+            size="2"
+            className="header-avatar-control border border-gray-300"
+            style={{
+              display: "inline-flex",
+              flexShrink: 0,
+              width: 32,
+              minWidth: 32,
+              height: 32,
+              minHeight: 32,
+            }}
+          />
+          <span className="hidden max-w-24 truncate xl:inline">
+            {displayName}
+          </span>
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="end">
+        <DropdownMenu.Item disabled>{displayName}</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item color="red" onClick={onLogout}>
+          <ExitIcon />
+          {logoutLabel}
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+}
+
 export default function Header() {
   const { t } = useI18n();
   const pathname = usePathname();
@@ -59,42 +106,19 @@ export default function Header() {
     router.refresh();
   }
 
-  const authControl = status === "loading" ? null : !user ? (
-    <LoginModal />
-  ) : (
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger aria-label={user.name || user.email || "User menu"}>
-        <span className="inline-flex h-11 shrink-0 cursor-pointer items-center gap-2 rounded-md border border-gray-300 bg-white px-1.5 pr-3 text-sm font-semibold text-gray-700 shadow-sm transition hover:bg-orange-50 hover:text-[#d73f09] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d73f09] focus-visible:ring-offset-2">
-          <Avatar
-            fallback={fallback.toUpperCase()}
-            size="2"
-            className="header-avatar-control border border-gray-300"
-            style={{
-              display: "inline-flex",
-              flexShrink: 0,
-              width: 32,
-              minWidth: 32,
-              height: 32,
-              minHeight: 32,
-            }}
-          />
-          <span className="hidden max-w-24 truncate xl:inline">
-            {user.name || user.email}
-          </span>
-        </span>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content align="end">
-        <DropdownMenu.Item disabled>
-          {user.name || user.email || "Profile"}
-        </DropdownMenu.Item>
-        <DropdownMenu.Separator />
-        <DropdownMenu.Item color="red" onClick={handleLogout}>
-          <ExitIcon />
-          {t("nav.logout")}
-        </DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu.Root>
-  );
+  function renderAuthControl() {
+    if (status === "loading") return null;
+    if (!user) return <LoginModal />;
+
+    return (
+      <UserMenu
+        user={user}
+        fallback={fallback}
+        logoutLabel={t("nav.logout")}
+        onLogout={handleLogout}
+      />
+    );
+  }
 
   return (
     <motion.header
@@ -127,7 +151,7 @@ export default function Header() {
 
         <div className="flex min-w-max shrink-0 items-center justify-end gap-2">
           <LanguageToggle />
-          <div className="hidden sm:block lg:hidden">{authControl}</div>
+          <div className="hidden sm:block lg:hidden">{renderAuthControl()}</div>
           <button
             type="button"
             className="app-action-icon lg:hidden"
@@ -137,7 +161,7 @@ export default function Header() {
           >
             {menuOpen ? <Cross2Icon /> : <HamburgerMenuIcon />}
           </button>
-          <div className="hidden lg:block">{authControl}</div>
+          <div className="hidden lg:block">{renderAuthControl()}</div>
         </div>
       </div>
 
@@ -157,7 +181,7 @@ export default function Header() {
             </Link>
           </nav>
           <div className="mt-3 border-t border-orange-100 pt-3 sm:hidden">
-            {authControl}
+            {renderAuthControl()}
           </div>
         </div>
       )}

--- a/app/lib/productTranslations.test.ts
+++ b/app/lib/productTranslations.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { translateProductName } from "./productTranslations";
+
+const originalApiKey = process.env.OPENAI_API_KEY;
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  process.env.OPENAI_API_KEY = originalApiKey;
+  vi.unstubAllGlobals();
+});
+
+test("translateProductName requests structured translations", async () => {
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => ({
+    ok: true,
+    json: async () => ({
+      output: [
+        {
+          content: [
+            {
+              type: "output_text",
+              text: JSON.stringify({
+                en: "Acer monitor",
+                zhTw: "Acer 螢幕",
+                zhCn: "Acer 显示器",
+              }),
+            },
+          ],
+        },
+      ],
+    }),
+  } as Response));
+  vi.stubGlobal("fetch", fetchMock);
+
+  const result = await translateProductName("Acer 螢幕");
+
+  expect(result).toEqual({
+    en: "Acer monitor",
+    zhTw: "Acer 螢幕",
+    zhCn: "Acer 显示器",
+  });
+  const requestBody = fetchMock.mock.calls[0]?.[1]?.body;
+  expect(typeof requestBody).toBe("string");
+  const body = JSON.parse(requestBody as string);
+  expect(body.text.format).toMatchObject({
+    type: "json_schema",
+    name: "product_name_translations",
+    strict: true,
+  });
+  expect(body.text.format.schema.required).toEqual(["en", "zhTw", "zhCn"]);
+});
+
+test("translateProductName falls back to the original name when translation fails", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: false,
+      json: async () => ({}),
+    }))
+  );
+
+  await expect(translateProductName("Desk")).resolves.toEqual({
+    en: "Desk",
+    zhTw: "Desk",
+    zhCn: "Desk",
+  });
+});

--- a/app/lib/productTranslations.ts
+++ b/app/lib/productTranslations.ts
@@ -27,6 +27,34 @@ function cleanTranslation(value: unknown, fallback: string) {
   return text || fallback;
 }
 
+function extractResponseText(payload: any) {
+  if (typeof payload?.output_text === "string") {
+    return payload.output_text;
+  }
+
+  const output = Array.isArray(payload?.output) ? payload.output : [];
+  for (const item of output) {
+    const content = Array.isArray(item?.content) ? item.content : [];
+    for (const part of content) {
+      if (typeof part?.text === "string") {
+        return part.text;
+      }
+    }
+  }
+
+  const legacyContent = payload?.choices?.[0]?.message?.content;
+  return typeof legacyContent === "string" ? legacyContent : null;
+}
+
+function parseTranslationJson(text: string) {
+  const trimmed = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "");
+
+  return JSON.parse(trimmed);
+}
+
 export async function translateProductName(
   name: string
 ): Promise<Required<ProductNameTranslations>> {
@@ -63,7 +91,19 @@ export async function translateProductName(
         ],
         text: {
           format: {
-            type: "json_object",
+            type: "json_schema",
+            name: "product_name_translations",
+            strict: true,
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                en: { type: "string" },
+                zhTw: { type: "string" },
+                zhCn: { type: "string" },
+              },
+              required: ["en", "zhTw", "zhCn"],
+            },
           },
         },
       }),
@@ -74,13 +114,13 @@ export async function translateProductName(
     }
 
     const payload = await response.json();
-    const text = payload.output_text || payload.output?.[0]?.content?.[0]?.text;
+    const text = extractResponseText(payload);
 
     if (!text) {
       return fallback;
     }
 
-    const parsed = JSON.parse(text);
+    const parsed = parseTranslationJson(text);
 
     return {
       en: cleanTranslation(parsed.en, name),


### PR DESCRIPTION
## Summary
- Fix product name auto-translation by using OpenAI structured output and robust response parsing.
- Preserve translated name fields when Supabase insert fallback only needs to remove unrelated optional schema fields.
- Refactor the Header auth control so mobile and desktop render separate dropdown/login instances, preventing mobile logout layout breakage.

## Verification
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run`
- `$env:NEXT_TELEMETRY_DISABLED='1'; npx.cmd next build --debug`
- `git diff --check`
- Playwright mobile smoke at 390px: header/menu had no horizontal overflow; only observed console error was unrelated `/favicon.ico` 404.