### PR TITLE
Add total user count to home stats

### DIFF
--- a/app/api/home/presence/route.ts
+++ b/app/api/home/presence/route.ts
@@ -39,10 +39,24 @@ async function countWithSupabase(sessionId: string) {
   return count ?? 1;
 }
 
+async function countTotalUsers() {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from("users")
+    .select("id", { count: "exact", head: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return count ?? 0;
+}
+
 export async function POST(request: NextRequest) {
   const existingSessionId = request.cookies.get(cookieName)?.value;
   const sessionId = existingSessionId || randomUUID();
   let onlineUsers = 1;
+  let totalUsers: number | null = null;
 
   try {
     onlineUsers = await countWithSupabase(sessionId);
@@ -50,8 +64,15 @@ export async function POST(request: NextRequest) {
     console.warn("Presence fallback used:", error);
   }
 
+  try {
+    totalUsers = await countTotalUsers();
+  } catch (error) {
+    console.warn("Total users fallback used:", error);
+  }
+
   const response = NextResponse.json({
     onlineUsers,
+    totalUsers,
     activeWindowMinutes,
   });
 

--- a/app/components/OnlineUsersCard.tsx
+++ b/app/components/OnlineUsersCard.tsx
@@ -8,11 +8,13 @@ import { useI18n } from "../i18n";
 
 type PresencePayload = {
   onlineUsers: number;
+  totalUsers: number | null;
 };
 
 export default function OnlineUsersCard() {
   const { t } = useI18n();
   const [onlineUsers, setOnlineUsers] = useState<number | null>(null);
+  const [totalUsers, setTotalUsers] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -29,10 +31,12 @@ export default function OnlineUsersCard() {
         const payload = (await response.json()) as PresencePayload;
         if (!cancelled) {
           setOnlineUsers(payload.onlineUsers);
+          setTotalUsers(payload.totalUsers);
         }
       } catch {
         if (!cancelled) {
           setOnlineUsers(1);
+          setTotalUsers(null);
         }
       }
     }
@@ -52,13 +56,23 @@ export default function OnlineUsersCard() {
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-orange-50 text-[#d73f09]">
           <PersonIcon />
         </div>
-        <div>
-          <Text size="2" color="gray">
-            {t("home.onlineNow")}
-          </Text>
-          <Heading size="6">
-            {onlineUsers ?? "--"} {t("home.users")}
-          </Heading>
+        <div className="grid min-w-0 flex-1 grid-cols-2 gap-4">
+          <div>
+            <Text size="2" color="gray">
+              {t("home.onlineNow")}
+            </Text>
+            <Heading size="5">
+              {onlineUsers ?? "--"} {t("home.users")}
+            </Heading>
+          </div>
+          <div className="border-l border-orange-100 pl-4">
+            <Text size="2" color="gray">
+              {t("home.totalUsers")}
+            </Text>
+            <Heading size="5">
+              {totalUsers ?? "--"} {t("home.users")}
+            </Heading>
+          </div>
         </div>
       </div>
     </Card>

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -79,6 +79,7 @@ const dictionaries = {
     "home.fundingNote": "Tips are voluntary payments for the project and are not charity fundraising.",
     "home.fundingUse": "Hosting, email, and AI tools",
     "home.onlineNow": "Currently online",
+    "home.totalUsers": "Total users",
     "home.users": "users",
     "marketplace.title": "Find campus deals faster.",
     "marketplace.subtitle":
@@ -343,6 +344,7 @@ const dictionaries = {
     "home.fundingNote": "打賞是給專案的自願付款，並非慈善募款。",
     "home.fundingUse": "主機、email 與 AI 工具",
     "home.onlineNow": "目前在線",
+    "home.totalUsers": "總用戶數",
     "home.users": "位使用者",
     "marketplace.title": "更快找到校園好物。",
     "marketplace.subtitle":
@@ -611,6 +613,7 @@ const zhCnDictionary: Record<TranslationKey, string> = {
   "home.fundingNote": "打赏是给项目的自愿付款，并非慈善募款。",
   "home.fundingUse": "主机、email 与 AI 工具",
   "home.onlineNow": "目前在线",
+  "home.totalUsers": "总用户数",
   "home.users": "位用户",
   "marketplace.title": "更快找到校园好物。",
   "marketplace.subtitle":


### PR DESCRIPTION
## Summary
- Keep the existing homepage online presence metric.
- Add total registered users from `public.users` to the same stats card.
- Add English, Traditional Chinese, and Simplified Chinese labels for the new metric.

## Verification
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run`
- `$env:NEXT_TELEMETRY_DISABLED='1'; npx.cmd next build --debug`
- `git diff --check`
- Playwright mobile smoke at 390px: stats card text is present and no horizontal overflow.