### PR TITLE
Prompt login from home CTA buttons

### DIFF
--- a/app/components/LoginModal.tsx
+++ b/app/components/LoginModal.tsx
@@ -1,19 +1,39 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, type ReactNode, useState } from "react";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { Dialog, Flex, Button } from "@radix-ui/themes";
 import { useI18n } from "../i18n";
 
-export default function LoginModal({ redirectTo = "/overview" }: { redirectTo?: string }) {
+type LoginModalProps = {
+  redirectTo?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: ReactNode;
+};
+
+export default function LoginModal({
+  redirectTo = "/overview",
+  open,
+  onOpenChange,
+  trigger,
+}: LoginModalProps) {
   const { t } = useI18n();
   const router = useRouter();
-  const [isOpen, setIsOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isOpen = open ?? internalOpen;
+
+  function setIsOpen(nextOpen: boolean) {
+    onOpenChange?.(nextOpen);
+    if (open === undefined) {
+      setInternalOpen(nextOpen);
+    }
+  }
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -40,20 +60,22 @@ export default function LoginModal({ redirectTo = "/overview" }: { redirectTo?: 
 
   return (
     <>
-      <Button
-        size="3"
-        variant="outline"
-        className="min-w-[76px] shrink-0 whitespace-nowrap border-[#d73f09] px-3 text-[#d73f09]"
-        style={{
-          flexShrink: 0,
-          minWidth: "76px",
-          width: "auto",
-          whiteSpace: "nowrap",
-        }}
-        onClick={() => setIsOpen(true)}
-      >
-        {t("auth.login")}
-      </Button>
+      {trigger !== undefined ? trigger : (
+        <Button
+          size="3"
+          variant="outline"
+          className="min-w-[76px] shrink-0 whitespace-nowrap border-[#d73f09] px-3 text-[#d73f09]"
+          style={{
+            flexShrink: 0,
+            minWidth: "76px",
+            width: "auto",
+            whiteSpace: "nowrap",
+          }}
+          onClick={() => setIsOpen(true)}
+        >
+          {t("auth.login")}
+        </Button>
+      )}
       <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
         <Dialog.Content maxWidth="450px">
           <Dialog.Title>{t("auth.login")}</Dialog.Title>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,8 @@ import {
   LockClosedIcon,
 } from "@radix-ui/react-icons";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import TimezoneCards from "./components/TimezoneCards";
 import OnlineUsersCard from "./components/OnlineUsersCard";
 import LoginModal from "./components/LoginModal";
@@ -21,7 +23,10 @@ import { useI18n } from "./i18n";
 
 export default function HomePage() {
   const { t } = useI18n();
+  const router = useRouter();
+  const { data: session, status } = useSession();
   const [redirectPath, setRedirectPath] = useState<string | null>(null);
+  const [loginPromptPath, setLoginPromptPath] = useState<string | null>(null);
 
   useEffect(() => {
     const from = new URLSearchParams(window.location.search).get("from");
@@ -37,6 +42,17 @@ export default function HomePage() {
     if (redirectPath.startsWith("/overview")) return t("nav.marketplace");
     return "OSUTrade";
   }, [redirectPath, t]);
+
+  function handleProtectedCta(path: string) {
+    if (status === "loading") return;
+
+    if (status === "authenticated" && session?.user) {
+      router.push(path);
+      return;
+    }
+
+    setLoginPromptPath(path);
+  }
 
   return (
     <Theme
@@ -81,25 +97,33 @@ export default function HomePage() {
                 </Text>
 
                 <div className="mt-6 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
-                  <Link href="/overview" className="block">
-                    <Button
-                      size="4"
-                      highContrast
-                      className="h-12 w-full justify-center rounded-md px-5"
-                    >
-                      {t("nav.marketplace")}
-                    </Button>
-                  </Link>
-                  <Link href="/sell" className="block">
-                    <Button
-                      size="4"
-                      variant="outline"
-                      className="h-12 w-full justify-center rounded-md border-[#d73f09] px-5 text-[#d73f09] sm:w-auto"
-                    >
-                      {t("marketplace.listItem")}
-                    </Button>
-                  </Link>
+                  <Button
+                    size="4"
+                    highContrast
+                    className="h-12 w-full justify-center rounded-md px-5"
+                    disabled={status === "loading"}
+                    onClick={() => handleProtectedCta("/overview")}
+                  >
+                    {t("nav.marketplace")}
+                  </Button>
+                  <Button
+                    size="4"
+                    variant="outline"
+                    className="h-12 w-full justify-center rounded-md border-[#d73f09] px-5 text-[#d73f09] sm:w-auto"
+                    disabled={status === "loading"}
+                    onClick={() => handleProtectedCta("/sell")}
+                  >
+                    {t("marketplace.listItem")}
+                  </Button>
                 </div>
+                <LoginModal
+                  redirectTo={loginPromptPath ?? "/overview"}
+                  open={loginPromptPath !== null}
+                  onOpenChange={(open) => {
+                    if (!open) setLoginPromptPath(null);
+                  }}
+                  trigger={null}
+                />
               </div>
 
               <Card className="app-card p-4">


### PR DESCRIPTION
## Summary
- Gate the homepage Marketplace and List Item CTA buttons behind login when the visitor is signed out.
- Reuse `LoginModal` in controlled mode so successful login redirects to the intended CTA target.
- Preserve existing standalone LoginModal usage in the header and signup/login panel.

## Verification
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run`
- `$env:NEXT_TELEMETRY_DISABLED='1'; npx.cmd next build --debug`
- `git diff --check`
- Playwright smoke: signed-out Marketplace and List Item CTAs stay on `/` and open the Login dialog.