### PR TITLE
Count total users from Supabase Auth

### DIFF
--- a/app/api/home/presence/route.ts
+++ b/app/api/home/presence/route.ts
@@ -41,6 +41,33 @@ async function countWithSupabase(sessionId: string) {
 
 async function countTotalUsers() {
   const supabase = createAdminClient();
+  const perPage = 1000;
+  let page = 1;
+  let total = 0;
+
+  while (true) {
+    const { data, error } = await supabase.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    const users = data.users ?? [];
+    total += users.length;
+
+    if (users.length < perPage) {
+      return total;
+    }
+
+    page += 1;
+  }
+}
+
+async function countProfileUsers() {
+  const supabase = createAdminClient();
   const { count, error } = await supabase
     .from("users")
     .select("id", { count: "exact", head: true });
@@ -67,7 +94,12 @@ export async function POST(request: NextRequest) {
   try {
     totalUsers = await countTotalUsers();
   } catch (error) {
-    console.warn("Total users fallback used:", error);
+    console.warn("Auth users count fallback used:", error);
+    try {
+      totalUsers = await countProfileUsers();
+    } catch (profileError) {
+      console.warn("Profile users count fallback used:", profileError);
+    }
   }
 
   const response = NextResponse.json({


### PR DESCRIPTION
## Summary
- Fix the homepage total user count to use Supabase Auth users instead of the `public.users` profile table.
- Count Auth users through the Supabase admin API with pagination so it matches the Supabase Auth Users dashboard.
- Keep `public.users` count as a fallback if Auth admin count fails.

## Verification
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run`
- `$env:NEXT_TELEMETRY_DISABLED='1'; npx.cmd next build --debug`
- `git diff --check`
- Local API smoke returns `totalUsers: null` without `SUPABASE_SERVICE_ROLE_KEY`, which is expected for the local env; production will require the service role key to count Auth users.