### PR TITLE
Fix tip support URL

### DIFF
--- a/app/api/home/funding/route.ts
+++ b/app/api/home/funding/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+const supportUrl = "https://buymeacoffee.com/osutrade";
+
 function numberFromEnv(name: string, fallback: number) {
   const value = Number(process.env[name]);
   return Number.isFinite(value) && value >= 0 ? value : fallback;
@@ -11,8 +13,6 @@ export async function GET() {
   const raised = hasRaisedConfig
     ? Math.min(numberFromEnv("FUNDING_RAISED_USD", 0), goal)
     : null;
-  const supportUrl =
-    process.env.FUNDING_SUPPORT_URL || "https://buymeacoffee.com/osutrade";
 
   return NextResponse.json({
     raised,


### PR DESCRIPTION
## Summary
- Fix the tip button URL by making the funding API always return the canonical Buy Me a Coffee link.
- Prevent `FUNDING_SUPPORT_URL` from overriding the homepage tip card with an incorrect URL.

## Verification
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run`
- `$env:NEXT_TELEMETRY_DISABLED='1'; npx.cmd next build --debug`
- `git diff --check`
- Local funding API smoke returns `supportUrl: https://buymeacoffee.com/osutrade`.