### PR TITLE
Require complete Google auth config

### DIFF
--- a/app/api/auth/providers/route.ts
+++ b/app/api/auth/providers/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
+import { getGoogleAuthConfig } from "@/utils/auth/googleConfig";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const google =
-    Boolean(process.env.GOOGLE_CLIENT_ID) &&
-    Boolean(process.env.GOOGLE_CLIENT_SECRET);
+  const google = getGoogleAuthConfig().configured;
 
   return NextResponse.json({
     google,

--- a/auth.ts
+++ b/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";
 import type { AppAuthUser } from "@/utils/auth/googleProfile";
+import { getGoogleAuthConfig } from "@/utils/auth/googleConfig";
 
 type User = AppAuthUser;
 
@@ -11,8 +12,7 @@ type GoogleProfile = {
   email_verified?: boolean;
 };
 
-const googleClientId = process.env.GOOGLE_CLIENT_ID;
-const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+const googleAuthConfig = getGoogleAuthConfig();
 
 function getBaseUrl() {
   const baseUrl =
@@ -28,11 +28,13 @@ export const { auth, handlers } = NextAuth({
   pages: { signIn: "/" },
   trustHost: true,
   providers: [
-    ...(googleClientId && googleClientSecret
+    ...(googleAuthConfig.configured &&
+    googleAuthConfig.clientId &&
+    googleAuthConfig.clientSecret
       ? [
           Google({
-            clientId: googleClientId,
-            clientSecret: googleClientSecret,
+            clientId: googleAuthConfig.clientId,
+            clientSecret: googleAuthConfig.clientSecret,
           }),
         ]
       : []),
@@ -99,7 +101,7 @@ export const { auth, handlers } = NextAuth({
         const authUser = await upsertGoogleUserProfile({
           email: googleProfile?.email ?? user?.email,
           name: googleProfile?.name ?? user?.name,
-          emailVerified: googleProfile?.email_verified === true,
+          emailVerified: googleProfile?.email_verified,
         });
 
         token.sub = authUser.id;

--- a/utils/auth/googleConfig.test.ts
+++ b/utils/auth/googleConfig.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, test } from "vitest";
+import { getGoogleAuthConfig } from "./googleConfig";
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+test("enables Google auth only when OAuth and Supabase admin config are present", () => {
+  process.env.GOOGLE_CLIENT_ID = "google-client";
+  process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+
+  expect(getGoogleAuthConfig()).toMatchObject({
+    clientId: "google-client",
+    clientSecret: "google-secret",
+    configured: true,
+  });
+});
+
+test("does not enable Google auth without Supabase service role access", () => {
+  process.env.GOOGLE_CLIENT_ID = "google-client";
+  process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  expect(getGoogleAuthConfig().configured).toBe(false);
+});
+
+test.each([
+  ["Google client id", "GOOGLE_CLIENT_ID"],
+  ["Google client secret", "GOOGLE_CLIENT_SECRET"],
+  ["Supabase URL", "NEXT_PUBLIC_SUPABASE_URL"],
+  ["Supabase service role key", "SUPABASE_SERVICE_ROLE_KEY"],
+])("does not enable Google auth without %s", (_label, missingKey) => {
+  process.env.GOOGLE_CLIENT_ID = "google-client";
+  process.env.GOOGLE_CLIENT_SECRET = "google-secret";
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
+  delete process.env[missingKey];
+
+  expect(getGoogleAuthConfig().configured).toBe(false);
+});

--- a/utils/auth/googleConfig.ts
+++ b/utils/auth/googleConfig.ts
@@ -1,0 +1,12 @@
+export function getGoogleAuthConfig() {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  return {
+    clientId,
+    clientSecret,
+    configured: Boolean(clientId && clientSecret && supabaseUrl && serviceRoleKey),
+  };
+}


### PR DESCRIPTION
## Summary
- Require both Google OAuth credentials and Supabase admin credentials before enabling Google auth.
- Reuse the same provider-availability check for the frontend `/api/auth/providers` endpoint and NextAuth provider registration.
- Preserve Google's `email_verified` flag as `undefined` when omitted, so Google sign-in does not require a separate email verification step unless Google explicitly marks the email unverified.

## Validation
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run`
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx.cmd next build --debug`