### PR TITLE
Fix credentials login without self fetch

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,67 +1,27 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
+import {
+  authenticateWithPassword,
+  AuthLoginError,
+} from "@/utils/auth/passwordLogin";
 
 export async function POST(request: Request) {
-  // call POST when htto request with post
   try {
-    const { email, password } = await request.json(); // JavaScript Object Notation
+    const { email, password } = await request.json();
+    const user = await authenticateWithPassword(
+      String(email ?? ""),
+      String(password ?? "")
+    );
 
-    // Check email and password are not blank
-    if (!email || !password) {
+    return NextResponse.json(user, { status: 200 });
+  } catch (error) {
+    if (error instanceof AuthLoginError) {
       return NextResponse.json(
-        { message: "Email and password are required." },
-        { status: 400 } // 400 stands for client error
+        { errorCode: error.code, message: error.message },
+        { status: error.status }
       );
     }
 
-    const supabase = await createClient();
-
-    const { data, error } = await supabase.auth.signInWithPassword({
-      //signInWithPassword returns { data: { ... }, error: null } if successes
-      email,
-      password,
-    });
-
-    if (error) {
-      if (error.message.includes("Invalid login credentials")) {
-        return NextResponse.json(
-          {
-            errorCode: "INVALID_CREDENTIALS",
-            message: "The email or password you entered is incorrect.",
-          },
-          { status: 401 } // 401 stands for Unauthorized
-        );
-      }
-
-      if (error.message.includes("Email not confirmed")) {
-        return NextResponse.json(
-          {
-            errorCode: "UNCONFIRMED_EMAIL",
-            message: "Please confirm your email address before logging in.",
-          },
-          { status: 403 } // 403 stands for Unauthorized
-        );
-      }
-
-      return NextResponse.json(
-        { message: error.message },
-        { status: error.status || 500 }
-      ); // 500 stands for internal server error
-    }
-
-    const u = data.user;
-    // ✅ 回傳 NextAuth 需要的 user 形狀（至少含 id）
-    return NextResponse.json(
-      {
-        id: u.id,
-        email: u.email,
-        name: u.user_metadata?.full_name ?? u.email?.split("@")[0] ?? "User",
-        role: u.user_metadata?.role ?? "user",
-      },
-      { status: 200 }
-    );
-  } catch (e) {
-    console.error(e);
+    console.error(error);
     return NextResponse.json(
       { message: "An unexpected error occurred." },
       { status: 500 }

--- a/auth.ts
+++ b/auth.ts
@@ -46,20 +46,17 @@ export const { auth, handlers } = NextAuth({
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials): Promise<User | null> {
+        const { authenticateWithPassword } = await import(
+          "@/utils/auth/passwordLogin"
+        );
         const email = String(credentials?.email ?? "");
         const password = String(credentials?.password ?? "");
 
-        const res = await fetch(`${getBaseUrl()}/api/auth/login`, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ email, password }),
-          cache: "no-store",
-        });
-
-        if (!res.ok) return null;
-
-        const user = (await res.json()) as User;
-        return user?.id ? user : null;
+        try {
+          return await authenticateWithPassword(email, password);
+        } catch {
+          return null;
+        }
       },
     }),
     Credentials({

--- a/utils/auth/passwordLogin.test.ts
+++ b/utils/auth/passwordLogin.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createClient } from "@supabase/supabase-js";
+import { authenticateWithPassword, AuthLoginError } from "./passwordLogin";
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(),
+}));
+
+const signInWithPassword = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  vi.mocked(createClient).mockReturnValue({
+    auth: {
+      signInWithPassword,
+    },
+  } as never);
+});
+
+describe("authenticateWithPassword", () => {
+  test("returns the app auth user when Supabase accepts the credentials", async () => {
+    signInWithPassword.mockResolvedValue({
+      data: {
+        user: {
+          id: "user-id",
+          email: "student@example.com",
+          user_metadata: {
+            full_name: "Student Seller",
+            role: "seller",
+          },
+        },
+      },
+      error: null,
+    });
+
+    await expect(
+      authenticateWithPassword("student@example.com", "password")
+    ).resolves.toEqual({
+      id: "user-id",
+      email: "student@example.com",
+      name: "Student Seller",
+      role: "seller",
+    });
+    expect(signInWithPassword).toHaveBeenCalledWith({
+      email: "student@example.com",
+      password: "password",
+    });
+  });
+
+  test("maps invalid credentials to a typed login error", async () => {
+    signInWithPassword.mockResolvedValue({
+      data: { user: null },
+      error: {
+        message: "Invalid login credentials",
+        status: 400,
+      },
+    });
+
+    await expect(
+      authenticateWithPassword("student@example.com", "wrong")
+    ).rejects.toMatchObject({
+      code: "INVALID_CREDENTIALS",
+      status: 401,
+    });
+  });
+
+  test("maps unconfirmed email to a typed login error", async () => {
+    signInWithPassword.mockResolvedValue({
+      data: { user: null },
+      error: {
+        message: "Email not confirmed",
+        status: 400,
+      },
+    });
+
+    await expect(
+      authenticateWithPassword("student@example.com", "password")
+    ).rejects.toMatchObject({
+      code: "UNCONFIRMED_EMAIL",
+      status: 403,
+    });
+  });
+
+  test("rejects blank credentials before calling Supabase", async () => {
+    await expect(authenticateWithPassword("", "")).rejects.toBeInstanceOf(
+      AuthLoginError
+    );
+    expect(signInWithPassword).not.toHaveBeenCalled();
+  });
+});

--- a/utils/auth/passwordLogin.ts
+++ b/utils/auth/passwordLogin.ts
@@ -1,0 +1,102 @@
+import { createClient } from "@supabase/supabase-js";
+import type { AppAuthUser } from "./googleProfile";
+
+type LoginErrorCode =
+  | "INVALID_CREDENTIALS"
+  | "UNCONFIRMED_EMAIL"
+  | "MISSING_CREDENTIALS"
+  | "LOGIN_FAILED";
+
+export class AuthLoginError extends Error {
+  code: LoginErrorCode;
+  status: number;
+
+  constructor(code: LoginErrorCode, message: string, status: number) {
+    super(message);
+    this.name = "AuthLoginError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function createPasswordAuthClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !anonKey) {
+    throw new AuthLoginError(
+      "LOGIN_FAILED",
+      "Supabase login credentials are not configured.",
+      500
+    );
+  }
+
+  return createClient(supabaseUrl, anonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+function mapSupabaseLoginError(error: { message?: string; status?: number }) {
+  const message = error.message ?? "Unable to log in.";
+
+  if (message.includes("Invalid login credentials")) {
+    return new AuthLoginError(
+      "INVALID_CREDENTIALS",
+      "The email or password you entered is incorrect.",
+      401
+    );
+  }
+
+  if (message.includes("Email not confirmed")) {
+    return new AuthLoginError(
+      "UNCONFIRMED_EMAIL",
+      "Please confirm your email address before logging in.",
+      403
+    );
+  }
+
+  return new AuthLoginError("LOGIN_FAILED", message, error.status || 500);
+}
+
+export async function authenticateWithPassword(
+  email: string,
+  password: string
+): Promise<AppAuthUser> {
+  if (!email || !password) {
+    throw new AuthLoginError(
+      "MISSING_CREDENTIALS",
+      "Email and password are required.",
+      400
+    );
+  }
+
+  const supabase = createPasswordAuthClient();
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    throw mapSupabaseLoginError(error);
+  }
+
+  const user = data.user;
+
+  if (!user?.id || !user.email) {
+    throw new AuthLoginError(
+      "LOGIN_FAILED",
+      "Supabase did not return a valid user.",
+      500
+    );
+  }
+
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.user_metadata?.full_name ?? user.email.split("@")[0] ?? "User",
+    role: user.user_metadata?.role ?? "user",
+  };
+}


### PR DESCRIPTION
## Summary
- Move email/password login into a shared `authenticateWithPassword` helper backed directly by Supabase Auth.
- Update the NextAuth credentials provider to call the helper instead of server-side fetching this app's `/api/auth/login` endpoint.
- Keep `/api/auth/login` available as a thin API wrapper using the same helper and typed login errors.

## Why
Production was not showing `/api/auth/login` during credentials login because the NextAuth credentials callback depended on a self-fetch through `AUTH_BASE_URL`. In Vercel serverless this can fail before the login API is reached, so no Auth.js session token is created and `/overview` redirects back to `/`.

## Validation
- `npm.cmd test -- --run utils/auth/passwordLogin.test.ts`
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run`
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx.cmd next build --debug`