### PR TITLE
Avoid overriding Auth.js providers route

### DIFF
--- a/app/api/auth/provider-status/route.ts
+++ b/app/api/auth/provider-status/route.ts
@@ -4,9 +4,7 @@ import { getGoogleAuthConfig } from "@/utils/auth/googleConfig";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const google = getGoogleAuthConfig().configured;
-
   return NextResponse.json({
-    google,
+    google: getGoogleAuthConfig().configured,
   });
 }

--- a/app/components/GoogleAuthDialogCta.tsx
+++ b/app/components/GoogleAuthDialogCta.tsx
@@ -17,7 +17,9 @@ export default function GoogleAuthDialogCta({ redirectTo }: { redirectTo: string
 
     async function loadProviderStatus() {
       try {
-        const response = await fetch("/api/auth/providers", { cache: "no-store" });
+        const response = await fetch("/api/auth/provider-status", {
+          cache: "no-store",
+        });
         const providers = (await response.json()) as AuthProvidersResponse;
 
         if (!ignore) {


### PR DESCRIPTION
## Summary
- Move the app-specific Google availability endpoint from `/api/auth/providers` to `/api/auth/provider-status`.
- Update the login/signup Google CTA to read the renamed endpoint.
- Leave `/api/auth/providers` available for Auth.js built-in provider discovery used by `next-auth/react` sign-in.

## Why
`next-auth/react` uses Auth.js's built-in `/api/auth/providers` endpoint during `signIn("login")`. Our custom endpoint returned `{ "google": true }` instead of the Auth.js provider map, which can prevent the credentials callback from reaching the Supabase password login path.

## Validation
- `npm.cmd test -- --run`
- `npx.cmd tsc --noEmit`
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx.cmd next build --debug`