### PR TITLE
[codex] Add seller listing edits and request price notices

### DIFF
--- a/app/api/requests/route.ts
+++ b/app/api/requests/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { createAdminClient } from "@/utils/supabase/admin";
 import { isExpiredSentRequest, requestResponseWindowMs } from "@/app/lib/requestExpiry";
+import { getRequestPriceChange } from "@/app/lib/requestPricing";
 
 type RequestRow = {
   request_id: string;
@@ -11,6 +12,7 @@ type RequestRow = {
   note: string | null;
   status: string;
   created_at: string;
+  price_at_request?: number | string | null;
 };
 
 type ProductRow = {
@@ -43,6 +45,7 @@ function toRequest(row: RequestRow, product?: ProductRow, sellerEmail?: string) 
   const imageUrls = product
     ? normalizeImageUrls(product.image_urls, product.image_url)
     : [];
+  const priceChange = getRequestPriceChange(row, product?.price);
 
   return {
     id: row.request_id,
@@ -52,6 +55,9 @@ function toRequest(row: RequestRow, product?: ProductRow, sellerEmail?: string) 
     note: row.note ?? "",
     status,
     createdAt: row.created_at,
+    priceAtRequest: priceChange.priceAtRequest,
+    currentPrice: priceChange.currentPrice,
+    priceChanged: priceChange.changed,
     sellerEmail: status === "accepted" ? sellerEmail ?? null : null,
     sellerContact:
       status === "accepted"
@@ -107,7 +113,7 @@ export async function GET() {
     const supabase = createAdminClient();
     const { data, error } = await supabase
       .from("trade_requests")
-      .select("request_id, product_id, buyer_id, quantity, note, status, created_at")
+      .select("request_id, product_id, buyer_id, quantity, note, status, created_at, price_at_request")
       .eq("buyer_id", session.user.id)
       .order("created_at", { ascending: false });
 
@@ -208,7 +214,7 @@ export async function PATCH(request: Request) {
       .update({ status: "cancelled", updated_at: new Date().toISOString() })
       .eq("request_id", requestId)
       .eq("buyer_id", session.user.id)
-      .select("request_id, product_id, buyer_id, quantity, note, status, created_at")
+      .select("request_id, product_id, buyer_id, quantity, note, status, created_at, price_at_request")
       .single();
 
     if (error) {
@@ -318,10 +324,11 @@ export async function POST(request: Request) {
         buyer_id: session.user.id,
         quantity,
         note: note || null,
+        price_at_request: product.price,
         status: "sent",
       })
       .select(
-        "request_id, product_id, buyer_id, quantity, note, status, created_at"
+        "request_id, product_id, buyer_id, quantity, note, status, created_at, price_at_request"
       )
       .single();
 

--- a/app/api/seller/products/route.ts
+++ b/app/api/seller/products/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { createAdminClient } from "@/utils/supabase/admin";
+import { buildSellerProductUpdate } from "@/app/lib/sellerProductUpdate";
+import {
+  translateProductDescription,
+  translateProductName,
+} from "@/app/lib/productTranslations";
 
 type ProductStatus = "available" | "pending" | "sold" | "removed";
 
@@ -116,13 +121,14 @@ export async function PATCH(request: Request) {
       );
     }
 
-    const body = await request.json();
-    const productId = String(body.productId ?? "").trim();
-    const status = String(body.status ?? "").trim() as ProductStatus;
+  const body = await request.json();
+  const productId = String(body.productId ?? "").trim();
+  const hasStatus = Object.prototype.hasOwnProperty.call(body, "status");
+  const status = String(body.status ?? "").trim() as ProductStatus;
 
-    if (!productId || !productStatuses.has(status)) {
+    if (!productId || (hasStatus && !productStatuses.has(status))) {
       return NextResponse.json(
-        { message: "Product id and a valid status are required." },
+        { message: "Product id and a valid update are required." },
         { status: 400 }
       );
     }
@@ -130,7 +136,7 @@ export async function PATCH(request: Request) {
     const supabase = createAdminClient();
     const { data: existing, error: lookupError } = await supabase
       .from("products")
-      .select("product_id, quantity")
+      .select("*")
       .eq("product_id", productId)
       .eq("seller_id", session.user.id)
       .single();
@@ -139,15 +145,44 @@ export async function PATCH(request: Request) {
       throw lookupError;
     }
 
+    const updatedAt = new Date().toISOString();
     const currentQuantity = Number(existing.quantity ?? 0);
-    const nextValues =
-      status === "sold"
-        ? { status, quantity: 0, updated_at: new Date().toISOString() }
+    const editResult = buildSellerProductUpdate(existing, body, updatedAt);
+
+    if (editResult.ok === false) {
+      return NextResponse.json({ message: editResult.message }, { status: 400 });
+    }
+
+    const nextValues: Record<string, unknown> = hasStatus
+      ? status === "sold"
+        ? { ...editResult.values, status, quantity: 0, updated_at: updatedAt }
         : {
+            ...editResult.values,
             status,
-            quantity: Math.max(1, currentQuantity),
-            updated_at: new Date().toISOString(),
-          };
+            quantity:
+              Object.prototype.hasOwnProperty.call(editResult.values, "quantity")
+                ? editResult.values.quantity
+                : Math.max(1, currentQuantity),
+            updated_at: updatedAt,
+          }
+      : editResult.values;
+
+    if (Object.prototype.hasOwnProperty.call(body, "name")) {
+      const nameTranslations = await translateProductName(String(nextValues.name));
+      nextValues.name_en = nameTranslations.en;
+      nextValues.name_zh_tw = nameTranslations.zhTw;
+      nextValues.name_zh_cn = nameTranslations.zhCn;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, "description")) {
+      const description = String(body.description ?? "").trim();
+      const descriptionTranslations = description
+        ? await translateProductDescription(description)
+        : { en: "", zhTw: "", zhCn: "" };
+      nextValues.description_en = descriptionTranslations.en || null;
+      nextValues.description_zh_tw = descriptionTranslations.zhTw || null;
+      nextValues.description_zh_cn = descriptionTranslations.zhCn || null;
+    }
 
     const { data, error } = await supabase
       .from("products")
@@ -161,7 +196,7 @@ export async function PATCH(request: Request) {
       throw error;
     }
 
-    if (status === "sold") {
+    if (hasStatus && status === "sold") {
       await supabase
         .from("trade_requests")
         .update({ status: "declined", updated_at: new Date().toISOString() })

--- a/app/api/seller/requests/route.ts
+++ b/app/api/seller/requests/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { createAdminClient } from "@/utils/supabase/admin";
 import { isExpiredSentRequest, requestResponseWindowMs } from "@/app/lib/requestExpiry";
+import { getAcceptedRequestProductStatus } from "@/app/lib/sellerRequestAcceptance";
 
 type RequestStatus = "sent" | "accepted" | "declined" | "cancelled";
 type ResponseStatus = RequestStatus | "expired";
@@ -284,7 +285,8 @@ export async function PATCH(request: Request) {
     if (status === "accepted") {
       const availableQuantity = Number(product?.quantity ?? 1);
       const remainingQuantity = availableQuantity - data.quantity;
-      const nextProductStatus = remainingQuantity > 0 ? "available" : "sold";
+      const nextProductStatus =
+        getAcceptedRequestProductStatus(remainingQuantity);
 
       const { data: updatedProduct, error: productUpdateError } = await supabase
         .from("products")

--- a/app/components/GoogleAuthDialogCta.tsx
+++ b/app/components/GoogleAuthDialogCta.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Copy, ExternalLink } from "lucide-react";
 import { useI18n } from "../i18n";
+import {
+  detectEmbeddedAuthBrowser,
+  type EmbeddedAuthBrowser,
+} from "../lib/embeddedBrowser";
 import GoogleSignInButton from "./GoogleSignInButton";
 
 type AuthProvidersResponse = {
@@ -11,6 +16,9 @@ type AuthProvidersResponse = {
 export default function GoogleAuthDialogCta({ redirectTo }: { redirectTo: string }) {
   const { t } = useI18n();
   const [showGoogle, setShowGoogle] = useState(false);
+  const [embeddedBrowser, setEmbeddedBrowser] =
+    useState<EmbeddedAuthBrowser | null>(null);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     let ignore = false;
@@ -39,12 +47,56 @@ export default function GoogleAuthDialogCta({ redirectTo }: { redirectTo: string
     };
   }, []);
 
+  useEffect(() => {
+    setEmbeddedBrowser(detectEmbeddedAuthBrowser(window.navigator.userAgent));
+  }, []);
+
+  async function copyCurrentLink() {
+    if (!window.navigator.clipboard) {
+      return;
+    }
+
+    await window.navigator.clipboard.writeText(window.location.href);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  }
+
   if (!showGoogle) {
     return null;
   }
 
   return (
     <div className="mt-4 space-y-4">
+      {embeddedBrowser?.isEmbedded && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+          <div className="flex gap-3">
+            <ExternalLink
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-[#d73f09]"
+            />
+            <div className="min-w-0 space-y-2">
+              <div className="font-semibold">
+                {t("auth.embeddedBrowserTitle")}
+              </div>
+              <p className="leading-6 text-amber-900">
+                {t("auth.embeddedBrowserBody", {
+                  appName: embeddedBrowser.appName ?? "this app",
+                })}
+              </p>
+              <button
+                type="button"
+                onClick={copyCurrentLink}
+                className="inline-flex min-h-9 items-center gap-2 rounded-md border border-amber-300 bg-white px-3 text-sm font-semibold text-[#8f2805] shadow-sm transition hover:border-[#d73f09] hover:bg-orange-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d73f09] focus-visible:ring-offset-2"
+              >
+                <Copy aria-hidden="true" className="h-4 w-4" />
+                <span>
+                  {copied ? t("auth.linkCopied") : t("auth.copyCurrentLink")}
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <GoogleSignInButton redirectTo={redirectTo} />
       <div className="flex items-center gap-3 text-xs font-medium text-gray-500">
         <span className="h-px flex-1 bg-gray-200" />

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -53,6 +53,11 @@ const dictionaries = {
     "auth.continueWithGoogle": "Continue with Google",
     "auth.googleSignInError": "Could not start Google sign-in. Please try again.",
     "auth.orContinueWithEmail": "or continue with email",
+    "auth.embeddedBrowserTitle": "Open OSUTrade in Safari or Chrome",
+    "auth.embeddedBrowserBody":
+      "Google sign-in may be blocked inside {appName}. Open this page in Safari or Chrome, then try Google sign-in again.",
+    "auth.copyCurrentLink": "Copy current link",
+    "auth.linkCopied": "Link copied",
     "auth.requiredTitle": "Log in to continue",
     "auth.requiredBody": "Please log in or create an account to continue to {destination}.",
     "home.description":
@@ -323,6 +328,11 @@ const dictionaries = {
     "auth.continueWithGoogle": "使用 Google 繼續",
     "auth.googleSignInError": "無法啟動 Google 登入，請再試一次。",
     "auth.orContinueWithEmail": "或使用 Email 繼續",
+    "auth.embeddedBrowserTitle": "請用 Safari 或 Chrome 開啟 OSUTrade",
+    "auth.embeddedBrowserBody":
+      "Google 登入可能會被 {appName} 內建瀏覽器阻擋。請用 Safari 或 Chrome 開啟此頁，再重新使用 Google 登入。",
+    "auth.copyCurrentLink": "複製目前網址",
+    "auth.linkCopied": "已複製網址",
     "auth.requiredTitle": "請先登入以繼續",
     "auth.requiredBody": "請登入或建立帳號後繼續前往「{destination}」。",
     "home.description":
@@ -597,6 +607,11 @@ const zhCnDictionary: Record<TranslationKey, string> = {
   "auth.continueWithGoogle": "使用 Google 继续",
   "auth.googleSignInError": "无法启动 Google 登录，请再试一次。",
   "auth.orContinueWithEmail": "或使用 Email 继续",
+  "auth.embeddedBrowserTitle": "请用 Safari 或 Chrome 打开 OSUTrade",
+  "auth.embeddedBrowserBody":
+    "Google 登录可能会被 {appName} 内置浏览器阻挡。请用 Safari 或 Chrome 打开此页面，再重新使用 Google 登录。",
+  "auth.copyCurrentLink": "复制当前网址",
+  "auth.linkCopied": "已复制网址",
   "auth.requiredTitle": "请先登录以继续",
   "auth.requiredBody": "请登录或创建账号后继续前往「{destination}」。",
   "home.description":

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -243,6 +243,7 @@ const dictionaries = {
     "requests.completed": "Completed or closed",
     "requests.completedHelp": "Accepted, declined, or cancelled request history.",
     "requests.qty": "Qty {quantity}",
+    "requests.priceChangedNotice": "Seller changed the price from {oldPrice} to {newPrice}. Accepted trades keep their agreed price.",
     "requests.acceptedContact": "Seller accepted. Contact:",
     "requests.contactPending": "Contact details appear after the seller accepts your request.",
     "requests.cancel": "Cancel request",
@@ -284,6 +285,11 @@ const dictionaries = {
     "seller.responseExpired": "Response window expired.",
     "seller.accept": "Accept",
     "seller.decline": "Decline",
+    "seller.edit": "Edit",
+    "seller.cancelEdit": "Cancel",
+    "seller.saveEdit": "Save changes",
+    "seller.editLockedSold": "Sold listings cannot change price or quantity.",
+    "seller.priceChangeWarning": "Changing the price will notify buyers with active requests. Accepted trades are unchanged.",
   },
   zh: {
     "common.language": "語言",
@@ -516,6 +522,7 @@ const dictionaries = {
     "requests.completed": "已完成或已關閉",
     "requests.completedHelp": "已接受、已拒絕或已取消的需求紀錄。",
     "requests.qty": "數量 {quantity}",
+    "requests.priceChangedNotice": "賣家已將價格從 {oldPrice} 改為 {newPrice}。已接受的交易維持原本價格。",
     "requests.acceptedContact": "賣家已接受。聯絡方式：",
     "requests.contactPending": "賣家接受需求後，這裡會顯示聯絡方式。",
     "requests.cancel": "取消需求",
@@ -557,6 +564,11 @@ const dictionaries = {
     "seller.responseExpired": "回覆期限已過。",
     "seller.accept": "接受",
     "seller.decline": "拒絕",
+    "seller.edit": "編輯",
+    "seller.cancelEdit": "取消",
+    "seller.saveEdit": "儲存變更",
+    "seller.editLockedSold": "已售出的商品不能修改價格或數量。",
+    "seller.priceChangeWarning": "修改價格會通知尚未成交的買家；已接受的交易不受影響。",
   },
 } as const;
 
@@ -795,6 +807,7 @@ const zhCnDictionary: Record<TranslationKey, string> = {
   "requests.completed": "已完成或已关闭",
   "requests.completedHelp": "已接受、已拒绝或已取消的需求记录。",
   "requests.qty": "数量 {quantity}",
+  "requests.priceChangedNotice": "卖家已将价格从 {oldPrice} 改为 {newPrice}。已接受的交易维持原本价格。",
   "requests.acceptedContact": "卖家已接受。联系方式：",
   "requests.contactPending": "卖家接受需求后才会显示联系方式。",
   "requests.cancel": "取消需求",
@@ -836,6 +849,11 @@ const zhCnDictionary: Record<TranslationKey, string> = {
   "seller.responseExpired": "回复期限已过。",
   "seller.accept": "接受",
   "seller.decline": "拒绝",
+  "seller.edit": "编辑",
+  "seller.cancelEdit": "取消",
+  "seller.saveEdit": "保存更改",
+  "seller.editLockedSold": "已售出的商品不能修改价格或数量。",
+  "seller.priceChangeWarning": "修改价格会通知尚未成交的买家；已接受的交易不受影响。",
 };
 
 type I18nContextValue = {

--- a/app/lib/embeddedBrowser.test.ts
+++ b/app/lib/embeddedBrowser.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { detectEmbeddedAuthBrowser } from "./embeddedBrowser";
+
+describe("detectEmbeddedAuthBrowser", () => {
+  test("detects LINE in-app browser user agents", () => {
+    expect(
+      detectEmbeddedAuthBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Line/15.0.0 Mobile/15E148"
+      )
+    ).toMatchObject({
+      isEmbedded: true,
+      appName: "LINE",
+    });
+  });
+
+  test("detects Instagram in-app browser user agents", () => {
+    expect(
+      detectEmbeddedAuthBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Instagram 335.0.0.31.91 Mobile"
+      )
+    ).toMatchObject({
+      isEmbedded: true,
+      appName: "Instagram",
+    });
+  });
+
+  test("does not flag regular Safari or Chrome", () => {
+    expect(
+      detectEmbeddedAuthBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Version/17.0 Mobile/15E148 Safari/604.1"
+      )
+    ).toMatchObject({
+      isEmbedded: false,
+      appName: null,
+    });
+
+    expect(
+      detectEmbeddedAuthBrowser(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36"
+      )
+    ).toMatchObject({
+      isEmbedded: false,
+      appName: null,
+    });
+  });
+});

--- a/app/lib/embeddedBrowser.ts
+++ b/app/lib/embeddedBrowser.ts
@@ -1,0 +1,49 @@
+type EmbeddedBrowserMatch = {
+  pattern: RegExp;
+  appName: string;
+};
+
+const EMBEDDED_BROWSER_MATCHES: EmbeddedBrowserMatch[] = [
+  { pattern: /Line\//i, appName: "LINE" },
+  { pattern: /Instagram/i, appName: "Instagram" },
+  { pattern: /FBAN|FBAV|FBIOS|FB_IAB/i, appName: "Facebook" },
+  { pattern: /MicroMessenger/i, appName: "WeChat" },
+  { pattern: /LinkedInApp/i, appName: "LinkedIn" },
+];
+
+export type EmbeddedAuthBrowser = {
+  isEmbedded: boolean;
+  appName: string | null;
+};
+
+export function detectEmbeddedAuthBrowser(userAgent: string): EmbeddedAuthBrowser {
+  const normalizedUserAgent = userAgent.trim();
+
+  for (const match of EMBEDDED_BROWSER_MATCHES) {
+    if (match.pattern.test(normalizedUserAgent)) {
+      return {
+        isEmbedded: true,
+        appName: match.appName,
+      };
+    }
+  }
+
+  const isAndroidWebView = /; wv\)/i.test(normalizedUserAgent);
+  const isIosWebView =
+    /\b(iPhone|iPad|iPod)\b/i.test(normalizedUserAgent) &&
+    /AppleWebKit/i.test(normalizedUserAgent) &&
+    !/Safari/i.test(normalizedUserAgent) &&
+    !/CriOS|FxiOS|EdgiOS/i.test(normalizedUserAgent);
+
+  if (isAndroidWebView || isIosWebView) {
+    return {
+      isEmbedded: true,
+      appName: "in-app browser",
+    };
+  }
+
+  return {
+    isEmbedded: false,
+    appName: null,
+  };
+}

--- a/app/lib/requestExpiry.ts
+++ b/app/lib/requestExpiry.ts
@@ -3,9 +3,11 @@ export const requestResponseWindowMs = 48 * 60 * 60 * 1000;
 export function isExpiredSentRequest(row: {
   status: string;
   created_at: string;
+  now?: number;
 }) {
   return (
     row.status === "sent" &&
-    Date.now() - new Date(row.created_at).getTime() > requestResponseWindowMs
+    (row.now ?? Date.now()) - new Date(row.created_at).getTime() >
+      requestResponseWindowMs
   );
 }

--- a/app/lib/requestPricing.test.ts
+++ b/app/lib/requestPricing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import {
+  getRequestPriceChange,
+  shouldNotifyRequestPriceChange,
+} from "./requestPricing";
+
+const now = new Date("2026-06-17T12:00:00.000Z").getTime();
+
+describe("request price change notifications", () => {
+  test("notifies active sent requests when current price differs from request price", () => {
+    const change = getRequestPriceChange(
+      {
+        status: "sent",
+        created_at: "2026-06-17T11:00:00.000Z",
+        price_at_request: 20,
+      },
+      25,
+      now
+    );
+
+    expect(change).toEqual({
+      changed: true,
+      priceAtRequest: 20,
+      currentPrice: 25,
+    });
+    expect(shouldNotifyRequestPriceChange(change)).toBe(true);
+  });
+
+  test("does not notify accepted requests because they are treated as completed trades", () => {
+    const change = getRequestPriceChange(
+      {
+        status: "accepted",
+        created_at: "2026-06-17T11:00:00.000Z",
+        price_at_request: 20,
+      },
+      25,
+      now
+    );
+
+    expect(change.changed).toBe(false);
+    expect(shouldNotifyRequestPriceChange(change)).toBe(false);
+  });
+
+  test("does not notify expired sent requests", () => {
+    const change = getRequestPriceChange(
+      {
+        status: "sent",
+        created_at: "2026-06-14T11:00:00.000Z",
+        price_at_request: 20,
+      },
+      25,
+      now
+    );
+
+    expect(change.changed).toBe(false);
+  });
+});

--- a/app/lib/requestPricing.ts
+++ b/app/lib/requestPricing.ts
@@ -1,0 +1,50 @@
+import { isExpiredSentRequest } from "./requestExpiry";
+
+type RequestPriceRow = {
+  status: string;
+  created_at: string;
+  price_at_request?: number | string | null;
+};
+
+export type RequestPriceChange = {
+  changed: boolean;
+  priceAtRequest: number | null;
+  currentPrice: number | null;
+};
+
+function normalizePrice(value: number | string | null | undefined) {
+  const price = Number(value);
+  return Number.isFinite(price) ? price : null;
+}
+
+export function getRequestPriceChange(
+  row: RequestPriceRow,
+  currentPrice: number | string | null | undefined,
+  now = Date.now()
+): RequestPriceChange {
+  const priceAtRequest = normalizePrice(row.price_at_request);
+  const productPrice = normalizePrice(currentPrice);
+
+  if (
+    row.status !== "sent" ||
+    isExpiredSentRequest({ ...row, now }) ||
+    priceAtRequest === null ||
+    productPrice === null
+  ) {
+    return {
+      changed: false,
+      priceAtRequest,
+      currentPrice: productPrice,
+    };
+  }
+
+  return {
+    changed: Math.abs(priceAtRequest - productPrice) > 0.001,
+    priceAtRequest,
+    currentPrice: productPrice,
+  };
+}
+
+export function shouldNotifyRequestPriceChange(change: RequestPriceChange) {
+  return change.changed;
+}

--- a/app/lib/sellerProductUpdate.test.ts
+++ b/app/lib/sellerProductUpdate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { buildSellerProductUpdate } from "./sellerProductUpdate";
+
+describe("seller product edits", () => {
+  test("builds update values for editable product fields", () => {
+    const result = buildSellerProductUpdate(
+      {
+        status: "available",
+        quantity: 3,
+      },
+      {
+        name: "Desk lamp",
+        description: "Warm light, works well",
+        price: 18.5,
+        category: "home",
+        quantity: 4,
+        contactPhone: "541-555-0101",
+        contactLineId: "seller-line",
+        contactWechatId: "seller-wechat",
+      },
+      "2026-06-17T12:00:00.000Z"
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      values: {
+        name: "Desk lamp",
+        description: "Warm light, works well",
+        price: 18.5,
+        category: "home",
+        quantity: 4,
+        contact_phone: "541-555-0101",
+        contact_line_id: "seller-line",
+        contact_wechat_id: "seller-wechat",
+        updated_at: "2026-06-17T12:00:00.000Z",
+      },
+    });
+  });
+
+  test("rejects price and quantity edits for sold products", () => {
+    const result = buildSellerProductUpdate(
+      {
+        status: "sold",
+        quantity: 0,
+      },
+      {
+        price: 10,
+        quantity: 1,
+      },
+      "2026-06-17T12:00:00.000Z"
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Sold listings cannot change price or quantity.",
+    });
+  });
+});

--- a/app/lib/sellerProductUpdate.ts
+++ b/app/lib/sellerProductUpdate.ts
@@ -1,0 +1,90 @@
+type ProductStatus = "available" | "pending" | "sold" | "removed";
+
+type ExistingProduct = {
+  status: ProductStatus | string | null;
+  quantity: number | null;
+};
+
+export type SellerProductEditInput = {
+  name?: unknown;
+  description?: unknown;
+  price?: unknown;
+  category?: unknown;
+  quantity?: unknown;
+  contactPhone?: unknown;
+  contactLineId?: unknown;
+  contactWechatId?: unknown;
+};
+
+type SellerProductUpdateResult =
+  | { ok: true; values: Record<string, unknown> }
+  | { ok: false; message: string };
+
+function hasOwn(input: SellerProductEditInput, key: keyof SellerProductEditInput) {
+  return Object.prototype.hasOwnProperty.call(input, key);
+}
+
+function cleanText(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+export function buildSellerProductUpdate(
+  existing: ExistingProduct,
+  input: SellerProductEditInput,
+  updatedAt = new Date().toISOString()
+): SellerProductUpdateResult {
+  const values: Record<string, unknown> = {};
+  const editsPriceOrQuantity = hasOwn(input, "price") || hasOwn(input, "quantity");
+
+  if (existing.status === "sold" && editsPriceOrQuantity) {
+    return {
+      ok: false,
+      message: "Sold listings cannot change price or quantity.",
+    };
+  }
+
+  if (hasOwn(input, "name")) {
+    const name = cleanText(input.name);
+    if (!name) return { ok: false, message: "Name is required." };
+    values.name = name;
+  }
+
+  if (hasOwn(input, "description")) {
+    values.description = cleanText(input.description) || null;
+  }
+
+  if (hasOwn(input, "price")) {
+    const price = Number(input.price);
+    if (!Number.isFinite(price) || price <= 0) {
+      return { ok: false, message: "Price must be greater than 0." };
+    }
+    values.price = price;
+  }
+
+  if (hasOwn(input, "category")) {
+    values.category = cleanText(input.category) || "general";
+  }
+
+  if (hasOwn(input, "quantity")) {
+    const quantity = Number(input.quantity);
+    if (!Number.isInteger(quantity) || quantity < 0) {
+      return { ok: false, message: "Quantity must be 0 or greater." };
+    }
+    values.quantity = quantity;
+  }
+
+  if (hasOwn(input, "contactPhone")) {
+    values.contact_phone = cleanText(input.contactPhone) || null;
+  }
+
+  if (hasOwn(input, "contactLineId")) {
+    values.contact_line_id = cleanText(input.contactLineId) || null;
+  }
+
+  if (hasOwn(input, "contactWechatId")) {
+    values.contact_wechat_id = cleanText(input.contactWechatId) || null;
+  }
+
+  values.updated_at = updatedAt;
+  return { ok: true, values };
+}

--- a/app/lib/sellerRequestAcceptance.test.ts
+++ b/app/lib/sellerRequestAcceptance.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+import { getAcceptedRequestProductStatus } from "./sellerRequestAcceptance";
+
+describe("accepted request product status", () => {
+  test("keeps product available when accepted request leaves stock remaining", () => {
+    expect(getAcceptedRequestProductStatus(2)).toBe("available");
+  });
+
+  test("marks product pending when accepted request reserves all remaining stock", () => {
+    expect(getAcceptedRequestProductStatus(0)).toBe("pending");
+  });
+});

--- a/app/lib/sellerRequestAcceptance.ts
+++ b/app/lib/sellerRequestAcceptance.ts
@@ -1,0 +1,7 @@
+type ProductStatus = "available" | "pending";
+
+export function getAcceptedRequestProductStatus(
+  remainingQuantity: number
+): ProductStatus {
+  return remainingQuantity > 0 ? "available" : "pending";
+}

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -19,6 +19,9 @@ type BuyerRequest = {
   note: string;
   status: RequestStatus;
   createdAt: string;
+  priceAtRequest?: number | null;
+  currentPrice?: number | null;
+  priceChanged?: boolean;
   sellerEmail?: string | null;
   sellerContact?: {
     email?: string | null;
@@ -39,6 +42,7 @@ const currency = (n: number) =>
   n.toLocaleString("en-US", { style: "currency", currency: "USD" });
 const requestResponseWindowMs = 48 * 60 * 60 * 1000;
 const buyerRequestStatusStorageKey = "osutrade:buyer-request-statuses";
+const buyerRequestPriceStorageKey = "osutrade:buyer-request-prices";
 
 function getResponseDeadline(createdAt: string) {
   return new Date(new Date(createdAt).getTime() + requestResponseWindowMs);
@@ -67,12 +71,30 @@ export default function RequestsPage() {
           const previous = JSON.parse(
             window.localStorage.getItem(buyerRequestStatusStorageKey) || "{}"
           ) as Record<string, RequestStatus>;
+          const previousPrices = JSON.parse(
+            window.localStorage.getItem(buyerRequestPriceStorageKey) || "{}"
+          ) as Record<string, number>;
           const changed = nextRequests.find(
             (request) =>
               previous[request.id] && previous[request.id] !== request.status
           );
+          const priceChanged = nextRequests.find(
+            (request) =>
+              request.priceChanged &&
+              request.currentPrice !== null &&
+              request.currentPrice !== undefined &&
+              previousPrices[request.id] !== undefined &&
+              previousPrices[request.id] !== request.currentPrice
+          );
 
-          if (changed) {
+          if (priceChanged && priceChanged.priceAtRequest !== null && priceChanged.priceAtRequest !== undefined && priceChanged.currentPrice !== null && priceChanged.currentPrice !== undefined) {
+            setNotice(
+              t("requests.priceChangedNotice", {
+                oldPrice: currency(priceChanged.priceAtRequest),
+                newPrice: currency(priceChanged.currentPrice),
+              })
+            );
+          } else if (changed) {
             setNotice(
               t("requests.statusChangedNotice", {
                 status: t(`requests.status.${changed.status}` as any),
@@ -86,6 +108,17 @@ export default function RequestsPage() {
           JSON.stringify(
             Object.fromEntries(
               nextRequests.map((request) => [request.id, request.status])
+            )
+          )
+        );
+        window.localStorage.setItem(
+          buyerRequestPriceStorageKey,
+          JSON.stringify(
+            Object.fromEntries(
+              nextRequests.map((request) => [
+                request.id,
+                request.currentPrice ?? request.product?.price ?? null,
+              ])
             )
           )
         );
@@ -397,6 +430,10 @@ function RequestCard({
         locale
       )
     : `Item ${request.itemId}`;
+  const displayPrice =
+    request.status === "accepted" && request.priceAtRequest !== null && request.priceAtRequest !== undefined
+      ? request.priceAtRequest
+      : request.product?.price;
 
   return (
     <Card className="app-card p-4">
@@ -414,7 +451,9 @@ function RequestCard({
               </Text>
               <Text color="gray" size="2">
                 {t("requests.qty", { quantity: request.quantity })}
-                {request.product ? ` - ${currency(request.product.price)}` : ""}
+                {displayPrice !== null && displayPrice !== undefined
+                  ? ` - ${currency(displayPrice)}`
+                  : ""}
               </Text>
             </div>
             <StatusBadge status={request.status} />
@@ -425,6 +464,19 @@ function RequestCard({
               {request.note}
             </p>
           )}
+
+          {request.priceChanged &&
+            request.priceAtRequest !== null &&
+            request.priceAtRequest !== undefined &&
+            request.currentPrice !== null &&
+            request.currentPrice !== undefined && (
+              <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+                {t("requests.priceChangedNotice", {
+                  oldPrice: currency(request.priceAtRequest),
+                  newPrice: currency(request.currentPrice),
+                })}
+              </div>
+            )}
 
           {request.status === "accepted" && request.sellerContact ? (
             <div className="mt-3 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">

--- a/app/seller/page.tsx
+++ b/app/seller/page.tsx
@@ -16,6 +16,7 @@ type RequestStatus = "sent" | "accepted" | "declined" | "cancelled" | "expired";
 type SellerProduct = {
   id: string | number;
   name: string;
+  description?: string | null;
   nameTranslations?: ProductNameTranslations | null;
   price: number;
   category?: string | null;
@@ -27,6 +28,17 @@ type SellerProduct = {
   } | null;
   status: ProductStatus;
   quantity?: number | null;
+};
+
+type ProductEditValues = {
+  name: string;
+  description: string;
+  price: number;
+  category: string;
+  quantity: number;
+  contactPhone: string;
+  contactLineId: string;
+  contactWechatId: string;
 };
 
 type SellerRequest = {
@@ -226,7 +238,10 @@ export default function SellerPage() {
     }
   }
 
-  async function updateProduct(productId: string | number, status: ProductStatus) {
+  async function updateProduct(
+    productId: string | number,
+    updates: Partial<ProductEditValues> & { status?: ProductStatus }
+  ) {
     setActionError(null);
     setPendingProductId(productId);
 
@@ -234,7 +249,7 @@ export default function SellerPage() {
       const res = await fetch("/api/seller/products", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ productId, status }),
+        body: JSON.stringify({ productId, ...updates }),
       });
 
       if (!res.ok) {
@@ -351,7 +366,8 @@ export default function SellerPage() {
                     <ProductRow
                       key={product.id}
                       product={product}
-                      onStatus={(status) => updateProduct(product.id, status)}
+                      onStatus={(status) => updateProduct(product.id, { status })}
+                      onSave={(values) => updateProduct(product.id, values)}
                       busy={pendingProductId === product.id}
                       locale={locale}
                       t={t}
@@ -506,17 +522,43 @@ function SellerRequestSection({
 function ProductRow({
   product,
   onStatus,
+  onSave,
   busy,
   locale,
   t,
 }: {
   product: SellerProduct;
   onStatus: (status: ProductStatus) => void;
+  onSave: (values: ProductEditValues) => void;
   busy: boolean;
   locale: ReturnType<typeof useI18n>["locale"];
   t: ReturnType<typeof useI18n>["t"];
 }) {
   const displayName = pickProductName(product.name, product.nameTranslations, locale);
+  const [editing, setEditing] = useState(false);
+  const [editValues, setEditValues] = useState<ProductEditValues>(() => ({
+    name: product.name,
+    description: product.description ?? "",
+    price: Number(product.price ?? 0),
+    category: product.category ?? "general",
+    quantity: product.quantity ?? 0,
+    contactPhone: product.sellerContact?.phone ?? "",
+    contactLineId: product.sellerContact?.lineId ?? "",
+    contactWechatId: product.sellerContact?.wechatId ?? "",
+  }));
+  const isSold = product.status === "sold";
+  useEffect(() => {
+    setEditValues({
+      name: product.name,
+      description: product.description ?? "",
+      price: Number(product.price ?? 0),
+      category: product.category ?? "general",
+      quantity: product.quantity ?? 0,
+      contactPhone: product.sellerContact?.phone ?? "",
+      contactLineId: product.sellerContact?.lineId ?? "",
+      contactWechatId: product.sellerContact?.wechatId ?? "",
+    });
+  }, [product]);
   const statusActions: Array<{
     status: ProductStatus;
     label: string;
@@ -575,6 +617,21 @@ function ProductRow({
           </div>
 
           <div className="mt-4 flex flex-wrap gap-2">
+            {!isSold ? (
+              <Button
+                type="button"
+                size="2"
+                variant="soft"
+                onClick={() => setEditing((value) => !value)}
+                disabled={busy}
+              >
+                {editing ? t("seller.cancelEdit") : t("seller.edit")}
+              </Button>
+            ) : (
+              <Text color="gray" size="2" className="self-center">
+                {t("seller.editLockedSold")}
+              </Text>
+            )}
             {statusActions.map((action) => {
               const active = product.status === action.status;
 
@@ -603,6 +660,160 @@ function ProductRow({
               </Text>
             )}
           </div>
+          {editing && !isSold && (
+            <form
+              className="mt-4 grid gap-3 rounded-md border border-orange-100 bg-white p-3"
+              onSubmit={(event) => {
+                event.preventDefault();
+                onSave(editValues);
+                setEditing(false);
+              }}
+            >
+              <label className="text-sm font-medium text-gray-700">
+                {t("sell.itemName")}
+                <input
+                  className="app-input mt-1"
+                  value={editValues.name}
+                  onChange={(event) =>
+                    setEditValues((current) => ({
+                      ...current,
+                      name: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              <label className="text-sm font-medium text-gray-700">
+                {t("sell.description")}
+                <textarea
+                  className="app-input mt-1 min-h-20"
+                  value={editValues.description}
+                  onChange={(event) =>
+                    setEditValues((current) => ({
+                      ...current,
+                      description: event.target.value,
+                    }))
+                  }
+                />
+              </label>
+              <div className="grid gap-3 sm:grid-cols-3">
+                <label className="text-sm font-medium text-gray-700">
+                  {t("sell.price")}
+                  <input
+                    className="app-input mt-1"
+                    type="number"
+                    min="0.01"
+                    step="0.01"
+                    value={editValues.price}
+                    onChange={(event) =>
+                      setEditValues((current) => ({
+                        ...current,
+                        price: Number(event.target.value),
+                      }))
+                    }
+                    required
+                  />
+                </label>
+                <label className="text-sm font-medium text-gray-700">
+                  {t("sell.quantity")}
+                  <input
+                    className="app-input mt-1"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value={editValues.quantity}
+                    onChange={(event) =>
+                      setEditValues((current) => ({
+                        ...current,
+                        quantity: Number(event.target.value),
+                      }))
+                    }
+                    required
+                  />
+                </label>
+                <label className="text-sm font-medium text-gray-700">
+                  {t("marketplace.category")}
+                  <select
+                    className="app-input mt-1"
+                    value={editValues.category}
+                    onChange={(event) =>
+                      setEditValues((current) => ({
+                        ...current,
+                        category: event.target.value,
+                      }))
+                    }
+                  >
+                    {["general", "electronics", "clothing", "books", "home"].map(
+                      (category) => (
+                        <option key={category} value={category}>
+                          {t(`common.category.${category}` as any)}
+                        </option>
+                      )
+                    )}
+                  </select>
+                </label>
+              </div>
+              {Number(editValues.price) !== Number(product.price) && (
+                <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+                  {t("seller.priceChangeWarning")}
+                </p>
+              )}
+              <div className="grid gap-3 sm:grid-cols-3">
+                <label className="text-sm font-medium text-gray-700">
+                  {t("contact.phone")}
+                  <input
+                    className="app-input mt-1"
+                    value={editValues.contactPhone}
+                    onChange={(event) =>
+                      setEditValues((current) => ({
+                        ...current,
+                        contactPhone: event.target.value,
+                      }))
+                    }
+                  />
+                </label>
+                <label className="text-sm font-medium text-gray-700">
+                  {t("contact.line")}
+                  <input
+                    className="app-input mt-1"
+                    value={editValues.contactLineId}
+                    onChange={(event) =>
+                      setEditValues((current) => ({
+                        ...current,
+                        contactLineId: event.target.value,
+                      }))
+                    }
+                  />
+                </label>
+                <label className="text-sm font-medium text-gray-700">
+                  {t("contact.wechat")}
+                  <input
+                    className="app-input mt-1"
+                    value={editValues.contactWechatId}
+                    onChange={(event) =>
+                      setEditValues((current) => ({
+                        ...current,
+                        contactWechatId: event.target.value,
+                      }))
+                    }
+                  />
+                </label>
+              </div>
+              <div className="flex flex-wrap justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="soft"
+                  onClick={() => setEditing(false)}
+                  disabled={busy}
+                >
+                  {t("seller.cancelEdit")}
+                </Button>
+                <Button type="submit" highContrast disabled={busy}>
+                  {busy ? t("seller.saving") : t("seller.saveEdit")}
+                </Button>
+              </div>
+            </form>
+          )}
           <SellerContactPreview contact={product.sellerContact} t={t} />
         </div>
       </div>

--- a/supabase/mvp-schema.sql
+++ b/supabase/mvp-schema.sql
@@ -100,11 +100,15 @@ create table if not exists public.trade_requests (
   product_id text not null,
   buyer_id uuid not null references auth.users(id) on delete cascade,
   quantity integer not null check (quantity > 0),
+  price_at_request numeric,
   note text,
   status text not null default 'sent' check (status in ('sent', 'accepted', 'declined', 'cancelled')),
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
+
+alter table public.trade_requests
+  add column if not exists price_at_request numeric;
 
 alter table public.trade_requests enable row level security;
 


### PR DESCRIPTION
﻿## Summary

- Add embedded-browser guidance for Google sign-in, including copy-link fallback and detection tests.
- Add seller listing inline edits for core listing details, contact fields, quantity, and price.
- Store request-time prices and show buyers a price-change notice only for active, not-yet-accepted requests.
- Treat accepted requests as reserved/processing by moving fully reserved listings to `pending` instead of `sold`.

## Notes

- `trade_requests.price_at_request` is added to the Supabase MVP schema so accepted trades can preserve the agreed price.
- `sold` remains a seller-controlled final state after the trade is actually complete.
- Local `output/` Playwright artifacts were intentionally left untracked.

## Validation

- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run` (10 files, 35 tests passed)
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx.cmd next build --debug`
