### PR TITLE
Allow visitors to browse before login

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import {
   Badge,
   Button,
@@ -22,8 +23,10 @@ import {
 } from "@radix-ui/react-icons";
 import Header from "../components/Header";
 import EmptyState from "../components/EmptyState";
+import LoginModal from "../components/LoginModal";
 import { useI18n } from "../i18n";
 import { pickProductName, type ProductNameTranslations } from "../lib/productTranslations";
+import { shouldPromptLoginForRequestAction } from "../lib/requestActionAccess";
 
 type CartItem = {
   id: string;
@@ -60,19 +63,28 @@ async function saveCart(items: CartItem[]) {
 
 export default function CartPage() {
   const { t, locale } = useI18n();
+  const { data: session, status } = useSession();
   const [items, setItems] = useState<CartItem[]>([]);
   const [states, setStates] = useState<Record<string, ItemState>>({});
   const [activeRequestItemIds, setActiveRequestItemIds] = useState<Set<string>>(
     () => new Set()
   );
   const [loading, setLoading] = useState(true);
+  const [loginPromptOpen, setLoginPromptOpen] = useState(false);
 
   useEffect(() => {
+    if (status === "loading") return;
+
+    const requestStatus =
+      status === "authenticated" && session?.user
+        ? fetch("/api/requests", { cache: "no-store" }).then((res) =>
+            res.ok ? res.json() : { data: [] }
+          )
+        : Promise.resolve({ data: [] });
+
     Promise.all([
       fetch("/api/cart", { cache: "no-store" }).then((res) => res.json()),
-      fetch("/api/requests", { cache: "no-store" }).then((res) =>
-        res.ok ? res.json() : { data: [] }
-      ),
+      requestStatus,
     ])
       .then(([cartPayload, requestsPayload]) => {
         const cart = (cartPayload.data ?? []) as CartItem[];
@@ -98,7 +110,7 @@ export default function CartPage() {
         );
       })
       .finally(() => setLoading(false));
-  }, []);
+  }, [session?.user, status]);
 
   const subtotal = useMemo(
     () => items.reduce((acc, item) => acc + item.price * item.quantity, 0),
@@ -150,6 +162,16 @@ export default function CartPage() {
   }
 
   async function sendRequest(id: string) {
+    if (
+      shouldPromptLoginForRequestAction({
+        authStatus: status,
+        hasUser: !!session?.user,
+      })
+    ) {
+      setLoginPromptOpen(true);
+      return;
+    }
+
     const item = items.find((candidate) => candidate.id === id);
     if (!item) return;
     if (activeRequestItemIds.has(String(id))) {
@@ -201,6 +223,15 @@ export default function CartPage() {
 
   async function sendAll() {
     if (allSent) return;
+    if (
+      shouldPromptLoginForRequestAction({
+        authStatus: status,
+        hasUser: !!session?.user,
+      })
+    ) {
+      setLoginPromptOpen(true);
+      return;
+    }
 
     for (const item of items) {
       if (
@@ -216,6 +247,12 @@ export default function CartPage() {
     <Theme appearance="light" accentColor="orange" grayColor="sand">
       <main className="app-page">
         <Header />
+        <LoginModal
+          redirectTo="/cart"
+          open={loginPromptOpen}
+          onOpenChange={setLoginPromptOpen}
+          trigger={null}
+        />
         <div className="app-container">
           <div className="app-hero flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/app/lib/homeCtaAccess.test.ts
+++ b/app/lib/homeCtaAccess.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { getHomeCtaAction } from "./homeCtaAccess";
+
+describe("getHomeCtaAction", () => {
+  test("lets visitors browse the marketplace without opening login", () => {
+    expect(
+      getHomeCtaAction({
+        path: "/overview",
+        authStatus: "unauthenticated",
+        hasUser: false,
+      })
+    ).toEqual({ type: "navigate", path: "/overview" });
+  });
+
+  test("requires login before listing an item", () => {
+    expect(
+      getHomeCtaAction({
+        path: "/sell",
+        authStatus: "unauthenticated",
+        hasUser: false,
+      })
+    ).toEqual({ type: "login", path: "/sell" });
+  });
+});

--- a/app/lib/homeCtaAccess.ts
+++ b/app/lib/homeCtaAccess.ts
@@ -1,0 +1,21 @@
+type AuthStatus = "authenticated" | "loading" | "unauthenticated";
+
+export function getHomeCtaAction({
+  path,
+  authStatus,
+  hasUser,
+}: {
+  path: string;
+  authStatus: AuthStatus;
+  hasUser: boolean;
+}) {
+  if (path === "/overview") {
+    return { type: "navigate" as const, path };
+  }
+
+  if (authStatus === "authenticated" && hasUser) {
+    return { type: "navigate" as const, path };
+  }
+
+  return { type: "login" as const, path };
+}

--- a/app/lib/requestActionAccess.test.ts
+++ b/app/lib/requestActionAccess.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { shouldPromptLoginForRequestAction } from "./requestActionAccess";
+
+describe("shouldPromptLoginForRequestAction", () => {
+  test("prompts visitors to log in before sending a trade request", () => {
+    expect(
+      shouldPromptLoginForRequestAction({
+        authStatus: "unauthenticated",
+        hasUser: false,
+      })
+    ).toBe(true);
+  });
+
+  test("allows authenticated users to send trade requests", () => {
+    expect(
+      shouldPromptLoginForRequestAction({
+        authStatus: "authenticated",
+        hasUser: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/app/lib/requestActionAccess.ts
+++ b/app/lib/requestActionAccess.ts
@@ -1,0 +1,11 @@
+type AuthStatus = "authenticated" | "loading" | "unauthenticated";
+
+export function shouldPromptLoginForRequestAction({
+  authStatus,
+  hasUser,
+}: {
+  authStatus: AuthStatus;
+  hasUser: boolean;
+}) {
+  return authStatus !== "authenticated" || !hasUser;
+}

--- a/app/lib/routeAccess.test.ts
+++ b/app/lib/routeAccess.test.ts
@@ -7,9 +7,13 @@ describe("requiresLogin", () => {
     expect(requiresLogin("/overview?category=electronics")).toBe(false);
   });
 
-  test("keeps trade actions protected", () => {
+  test("allows visitors to review their cookie cart before sending a request", () => {
+    expect(requiresLogin("/cart")).toBe(false);
+    expect(requiresLogin("/cart?from=product")).toBe(false);
+  });
+
+  test("keeps seller and account request pages protected", () => {
     expect(requiresLogin("/sell")).toBe(true);
-    expect(requiresLogin("/cart")).toBe(true);
     expect(requiresLogin("/seller")).toBe(true);
     expect(requiresLogin("/requests")).toBe(true);
   });

--- a/app/lib/routeAccess.ts
+++ b/app/lib/routeAccess.ts
@@ -1,4 +1,4 @@
-const protectedPrefixes = ["/sell", "/cart", "/seller", "/requests"];
+const protectedPrefixes = ["/sell", "/seller", "/requests"];
 
 function normalizePath(path: string) {
   const [pathname] = path.split("?");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import ProductListCard from "./components/ProductListCard";
 import TipProgressCard from "./components/TipProgressCard";
 import Header from "./components/Header";
 import { useI18n } from "./i18n";
+import { getHomeCtaAction } from "./lib/homeCtaAccess";
 
 export default function HomePage() {
   const { t } = useI18n();
@@ -46,12 +47,18 @@ export default function HomePage() {
   function handleProtectedCta(path: string) {
     if (status === "loading") return;
 
-    if (status === "authenticated" && session?.user) {
-      router.push(path);
+    const action = getHomeCtaAction({
+      path,
+      authStatus: status,
+      hasUser: !!session?.user,
+    });
+
+    if (action.type === "navigate") {
+      router.push(action.path);
       return;
     }
 
-    setLoginPromptPath(path);
+    setLoginPromptPath(action.path);
   }
 
   return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,7 +29,6 @@ export default auth((req) => {
 export const config = {
   matcher: [
     "/sell/:path*",
-    "/cart/:path*",
     "/seller/:path*",
     "/requests/:path*",
     "/",


### PR DESCRIPTION
﻿## Summary
- Let visitors open Marketplace and Cart before creating an account.
- Keep login required for listing items, seller tools, request history, and sending trade requests.
- Show the login modal from Cart when a visitor tries to send a request, then return them to Cart after login.
- Avoid background `/api/requests` calls for anonymous cart visitors.

## Validation
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run` (21 files, 63 tests)
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx.cmd next build --debug`
- Playwright smoke test on production build:
  - `/overview` and `/cart` return 200 as visitor
  - `/sell`, `/seller`, `/requests` remain protected
  - visitor can add an item to cart and opens login modal when sending a request

## Release note
Draft PR for review only. Hold merge/deploy until the planned off-peak release window.
