### PR TITLE
Keep homepage visible after login

### DIFF
--- a/app/lib/routeAccess.test.ts
+++ b/app/lib/routeAccess.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { requiresLogin } from "./routeAccess";
+import { getMiddlewareRedirect, requiresLogin } from "./routeAccess";
 
 describe("requiresLogin", () => {
   test("allows visitors to browse the marketplace", () => {
@@ -16,5 +16,27 @@ describe("requiresLogin", () => {
     expect(requiresLogin("/sell")).toBe(true);
     expect(requiresLogin("/seller")).toBe(true);
     expect(requiresLogin("/requests")).toBe(true);
+  });
+});
+
+describe("getMiddlewareRedirect", () => {
+  test("does not redirect signed-in users away from the homepage", () => {
+    expect(
+      getMiddlewareRedirect({
+        pathname: "/",
+        search: "",
+        isLoggedIn: true,
+      })
+    ).toBeNull();
+  });
+
+  test("redirects visitors from protected pages back to login prompt on homepage", () => {
+    expect(
+      getMiddlewareRedirect({
+        pathname: "/sell",
+        search: "?draft=1",
+        isLoggedIn: false,
+      })
+    ).toEqual({ pathname: "/", from: "/sell?draft=1" });
   });
 });

--- a/app/lib/routeAccess.ts
+++ b/app/lib/routeAccess.ts
@@ -11,3 +11,19 @@ export function requiresLogin(path: string) {
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
   );
 }
+
+export function getMiddlewareRedirect({
+  pathname,
+  search,
+  isLoggedIn,
+}: {
+  pathname: string;
+  search: string;
+  isLoggedIn: boolean;
+}) {
+  if (requiresLogin(pathname) && !isLoggedIn) {
+    return { pathname: "/", from: pathname + (search || "") };
+  }
+
+  return null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,21 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { requiresLogin } from "@/app/lib/routeAccess";
+import { getMiddlewareRedirect } from "@/app/lib/routeAccess";
 
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const { pathname, search } = req.nextUrl;
 
-  const isProtected = requiresLogin(pathname);
-  const isAuthPage = pathname === "/";
+  const redirect = getMiddlewareRedirect({
+    pathname,
+    search,
+    isLoggedIn,
+  });
 
-  if (isProtected && !isLoggedIn) {
+  if (redirect) {
     const url = req.nextUrl.clone();
-    url.pathname = "/";
-    url.searchParams.set("from", pathname + (search || ""));
-    return NextResponse.redirect(url);
-  }
-
-  if (isAuthPage && isLoggedIn) {
-    const url = req.nextUrl.clone();
-    url.pathname = "/overview";
-    url.search = "";
+    url.pathname = redirect.pathname;
+    url.searchParams.set("from", redirect.from);
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
﻿## Summary
- Keep the homepage visible for signed-in users instead of redirecting `/` to `/overview`.
- Preserve the protected-route behavior for `/sell`, `/seller`, and `/requests` by redirecting visitors to `/?from=...`.
- Extract middleware redirect decision into a tested helper.

## Root cause
The middleware still had an old rule that redirected signed-in users from `/` to `/overview`. After adding homepage marketplace signals, this made the homepage impossible to browse while logged in.

## Validation
- `npm.cmd test -- --run app/lib/routeAccess.test.ts`
- `npx.cmd tsc --noEmit`
- `npm.cmd test -- --run` (22 files, 67 tests)
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx.cmd next build --debug`
- Local production smoke test:
  - `/` returns 200
  - `/overview` returns 200
  - `/cart` returns 200
  - `/sell`, `/seller`, `/requests` return 307 for visitors
