### PR TITLE
[codex] Move header outside page padding

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -245,14 +245,14 @@ export default function CartPage() {
 
   return (
     <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <Header />
+      <LoginModal
+        redirectTo="/cart"
+        open={loginPromptOpen}
+        onOpenChange={setLoginPromptOpen}
+        trigger={null}
+      />
       <main className="app-page">
-        <Header />
-        <LoginModal
-          redirectTo="/cart"
-          open={loginPromptOpen}
-          onOpenChange={setLoginPromptOpen}
-          trigger={null}
-        />
         <div className="app-container">
           <div className="app-hero flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -169,7 +169,7 @@ export default function Header() {
 
   return (
     <motion.header
-      className="fixed top-0 z-50 w-full border-b border-orange-100 bg-white/95 px-4 py-3 shadow-sm backdrop-blur-md"
+      className="fixed left-0 right-0 top-0 z-50 w-full border-b border-orange-100 bg-white/95 px-4 py-3 shadow-sm backdrop-blur-md"
       initial={{ y: -50, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6, ease: "easeOut" }}

--- a/app/docs/swagger/page.tsx
+++ b/app/docs/swagger/page.tsx
@@ -16,8 +16,8 @@ const SwaggerUI = dynamic(
 export default function SwaggerDocsPage() {
   return (
     <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <Header />
       <main className="app-page">
-        <Header />
         <section className="app-container">
           <div className="app-hero">
             <p className="app-eyebrow">API</p>

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -45,8 +45,8 @@ export default function ProductListPage() {
 
   return (
     <Theme appearance="light" accentColor="orange" grayColor="sand" radius="large">
+      <Header />
       <main className="app-page">
-        <Header />
 
         <div className="app-container">
           <section className="app-hero flex flex-col gap-5">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,8 +68,8 @@ export default function HomePage() {
       grayColor="sand"
       radius="large"
     >
+      <Header />
       <div className="app-page">
-        <Header />
         <div className="app-container space-y-6">
           {redirectPath && (
             <Card className="app-card border-amber-200 bg-amber-50 p-4">

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -105,8 +105,8 @@ export default function ProductDetailPage() {
   if (loading) {
     return (
       <Theme appearance="light" accentColor="orange" grayColor="sand">
+        <Header />
         <main className="app-page">
-          <Header />
           <div className="mx-auto max-w-5xl rounded-lg border border-orange-100 bg-white/85 p-8 text-center text-gray-600 shadow-sm">
             {t("product.loading")}
           </div>
@@ -118,8 +118,8 @@ export default function ProductDetailPage() {
   if (error || !product) {
     return (
       <Theme appearance="light" accentColor="orange" grayColor="sand">
+        <Header />
         <main className="app-page">
-          <Header />
           <div className="mx-auto max-w-3xl rounded-lg border border-red-100 bg-white/85 p-8 text-center shadow-sm">
             <h1 className="text-2xl font-bold text-gray-900">{t("product.unavailable")}</h1>
             <p className="mt-2 text-gray-600">{error || t("product.notFound")}</p>
@@ -150,8 +150,8 @@ export default function ProductDetailPage() {
 
   return (
     <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <Header />
       <main className="app-page">
-        <Header />
         <div className="mx-auto max-w-6xl">
           <Link
             href="/overview"

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -191,9 +191,8 @@ export default function RequestsPage() {
 
   return (
     <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <Header />
       <main className="app-page">
-        <Header />
-
         <section className="mx-auto max-w-5xl">
           <div className="app-hero">
             <div>

--- a/app/sell/page.tsx
+++ b/app/sell/page.tsx
@@ -236,8 +236,8 @@ export default function SellPage() {
 
   return (
     <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <Header />
       <main className="app-page">
-        <Header />
         <section className="mx-auto max-w-5xl">
           <div className="app-hero text-center md:text-left">
             <p className="app-eyebrow">{t("nav.sell")}</p>

--- a/app/seller/page.tsx
+++ b/app/seller/page.tsx
@@ -255,9 +255,8 @@ export default function SellerPage() {
 
   return (
     <Theme appearance="light" accentColor="orange" grayColor="sand">
+      <Header />
       <main className="app-page">
-        <Header />
-
         <section className="app-container">
           <div className="app-hero">
             <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">


### PR DESCRIPTION
## Summary
- render the fixed Header before each page's app-page padding container
- anchor the fixed header with left-0 and right-0 so it starts at the viewport edge
- keep the page content padding and centered containers unchanged

## Validation
- npm.cmd test -- --run
- Playwright at 1920px confirmed the banner bounding box starts at x=0 and the inner nav remains 1536px wide

## Notes
- Follow-up to #106: widening the inner header container helped, but the header still needed to sit outside app-page padding.